### PR TITLE
Add: analyze the metadata in another process, so we don't block the main

### DIFF
--- a/truewiki/__main__.py
+++ b/truewiki/__main__.py
@@ -1,6 +1,5 @@
 import click
 import logging
-import time
 
 from aiohttp import web
 from aiohttp.web_log import AccessLogger
@@ -76,11 +75,7 @@ def main(bind, port, storage, validate_all):
         validate.all()
         return
 
-    log.info("Loading metadata (this can take a while) ...")
-
-    start = time.time()
-    load_metadata(instance.folder)
-    log.info(f"Loading metadata done; took {time.time() - start:.2f} seconds")
+    load_metadata()
 
     webapp = web.Application()
     webapp.router.add_static("/uploads", f"{instance.folder}/File/")

--- a/truewiki/__main__.py
+++ b/truewiki/__main__.py
@@ -11,7 +11,10 @@ from . import (
     singleton,
     validate,
 )
-from .metadata import load_metadata
+from .metadata import (
+    click_metadata,
+    load_metadata,
+)
 from .storage.github import click_storage_github
 from .storage.local import click_storage_local
 from .user.github import click_user_github
@@ -58,6 +61,7 @@ class ErrorOnlyAccessLogger(AccessLogger):
     callback=click_helper.import_module("truewiki.storage", "Storage"),
 )
 @click_web_routes
+@click_metadata
 @click_storage_local
 @click_storage_github
 @click_user_session

--- a/truewiki/metadata.py
+++ b/truewiki/metadata.py
@@ -1,4 +1,5 @@
 import asyncio
+import click
 import glob
 import hashlib
 import json
@@ -8,6 +9,7 @@ import time
 
 from collections import defaultdict
 from concurrent import futures
+from openttd_helpers import click_helper
 
 from . import singleton
 from .wiki_page import WikiPage
@@ -252,3 +254,16 @@ class ReloadHelper:
 
         log.info(f"Loading metadata done; took {time.time() - start:.2f} seconds")
         return TRANSLATIONS, CATEGORIES, PAGES
+
+
+@click_helper.extend
+@click.option(
+    "--cache-metadata-file",
+    help="File used to cache metadata.",
+    default=".cache_metadata.json",
+    show_default=True,
+)
+def click_metadata(cache_metadata_file):
+    global CACHE_FILENAME
+
+    CACHE_FILENAME = cache_metadata_file

--- a/truewiki/metadata.py
+++ b/truewiki/metadata.py
@@ -1,26 +1,38 @@
+import asyncio
 import glob
 import hashlib
 import json
+import logging
 import os
+import time
 
 from collections import defaultdict
+from concurrent import futures
 
 from . import singleton
 from .wiki_page import WikiPage
 
+log = logging.getLogger(__name__)
+
 CACHE_FILENAME = ".cache_metadata.json"
 
-TRANSLATIONS = defaultdict(list)
-CATEGORIES = defaultdict(list)
-PAGES = defaultdict(
-    lambda: {
+
+def page():
+    return {
         "translations": [],
         "categories": [],
         "dependencies": set(),
         "dependent_on": [],
         "digest": "",
     }
-)
+
+
+TRANSLATIONS = defaultdict(list)
+CATEGORIES = defaultdict(list)
+PAGES = defaultdict(page)
+
+RELOAD_BUSY = asyncio.Event()
+RELOAD_BUSY.set()
 
 
 def translation_callback(wtp, wiki_page, page):
@@ -61,12 +73,9 @@ def _forget_page(page):
     for translation in PAGES[page]["translations"]:
         TRANSLATIONS[translation].remove(page)
 
-    if not PAGES[page]["dependencies"]:
-        del PAGES[page]
-    else:
-        PAGES[page]["dependent_on"].clear()
-        PAGES[page]["categories"].clear()
-        PAGES[page]["translations"].clear()
+    PAGES[page]["dependent_on"].clear()
+    PAGES[page]["categories"].clear()
+    PAGES[page]["translations"].clear()
 
 
 def _analyze_page(page):
@@ -86,7 +95,7 @@ def _analyze_page(page):
         callback(wtp, wiki_page, page)
 
 
-def page_changed(page, notified=None):
+def _page_changed(page, notified=None):
     if notified is None:
         notified = set()
 
@@ -102,10 +111,10 @@ def page_changed(page, notified=None):
 
     # Notify all dependencies of a page change.
     for dependency in PAGES[page]["dependencies"] | dependencies:
-        page_changed(dependency, notified)
+        _page_changed(dependency, notified)
 
 
-def scan_folder(folder, notified=None, check_hash=False):
+def _scan_folder(folder, notified=None):
     pages_seen = set()
 
     if notified is None:
@@ -114,24 +123,27 @@ def scan_folder(folder, notified=None, check_hash=False):
     for node in glob.glob(f"{singleton.STORAGE.folder}/{folder}/*"):
         if os.path.isdir(node):
             folder = node[len(singleton.STORAGE.folder) + 1 :]
-            pages_seen.update(scan_folder(folder, notified, check_hash))
+            pages_seen.update(_scan_folder(folder, notified))
             continue
 
         if node.endswith(".mediawiki"):
             page = node[len(singleton.STORAGE.folder) + 1 : -len(".mediawiki")]
             pages_seen.add(page)
 
-            if check_hash:
-                hash = hashlib.sha256()
-                with open(node, "rb") as fp:
-                    hash.update(fp.read())
-                digest = hash.hexdigest()
+            hash = hashlib.sha256()
+            with open(node, "rb") as fp:
+                hash.update(fp.read())
+            digest = hash.hexdigest()
 
-                if PAGES[page]["digest"] == digest:
-                    continue
-                PAGES[page]["digest"] = digest
+            # Use the hash of the file to see if this file is changed; if not,
+            # we can safely skip analyzing it again. If any template used in
+            # this page is changed, that template will trigger the correct
+            # chain of updates.
+            if PAGES[page]["digest"] == digest:
+                continue
+            PAGES[page]["digest"] = digest
 
-            page_changed(page, notified)
+            _page_changed(page, notified)
 
     return pages_seen
 
@@ -142,53 +154,101 @@ def json_set_serialize(obj):
     raise TypeError
 
 
-def load_metadata(folder):
-    TRANSLATIONS.clear()
-    CATEGORIES.clear()
-    PAGES.clear()
+def load_metadata():
+    loop = asyncio.get_event_loop()
+    loop.create_task(out_of_process("load_metadata", None))
 
-    if os.path.exists(CACHE_FILENAME):
-        with open(CACHE_FILENAME, "r") as fp:
-            payload = json.loads(fp.read())
-            TRANSLATIONS.update(payload["translations"])
-            CATEGORIES.update(payload["categories"])
-            PAGES.update(payload["pages"])
 
-        # After JSON dumps/loads, set became lists; make sure all sets are sets again.
-        for page in PAGES:
-            PAGES[page]["dependencies"] = set(PAGES[page]["dependencies"])
+def page_changed(page):
+    loop = asyncio.get_event_loop()
+    loop.create_task(out_of_process("page_changed", page))
 
-    # Ensure no file is scanned more than once.
-    notified = set()
-    # Keep track of which pages we have seen.
-    pages_seen = set()
-    # Scan all folders with mediawiki files.
-    for subfolder in ("Page", "Template", "Category"):
-        pages_seen.update(scan_folder(f"{subfolder}", notified, check_hash=True))
 
-    # If we come from cache, validate that no file got removed; we should
-    # forget about those.
-    pages_known = set(page for page in PAGES if PAGES[page]["digest"])
-    for page in pages_seen:
-        if page in pages_known:
-            pages_known.remove(page)
-    for page in pages_known:
-        _forget_page(page)
+async def out_of_process(func, page):
+    global TRANSLATIONS, CATEGORIES, PAGES
 
-    # Sort all translations and categories; makes it easier for the render.
-    for translation in TRANSLATIONS:
-        TRANSLATIONS[translation] = sorted(TRANSLATIONS[translation], key=lambda name: (name.find("en/") < 0, name))
-    for category in CATEGORIES:
-        CATEGORIES[category] = sorted(CATEGORIES[category])
+    await RELOAD_BUSY.wait()
+    RELOAD_BUSY.clear()
 
-    with open(CACHE_FILENAME, "w") as fp:
-        fp.write(
-            json.dumps(
-                {
-                    "translations": TRANSLATIONS,
-                    "categories": CATEGORIES,
-                    "pages": PAGES,
-                },
-                default=json_set_serialize,
+    try:
+        reload_helper = ReloadHelper(page)
+
+        # Run the reload in a new process, so we don't block the rest of the
+        # server while doing this job.
+        loop = asyncio.get_event_loop()
+        with futures.ProcessPoolExecutor(max_workers=1) as executor:
+            task = loop.run_in_executor(executor, getattr(reload_helper, func))
+            (
+                TRANSLATIONS,
+                CATEGORIES,
+                PAGES,
+            ) = await task
+    finally:
+        RELOAD_BUSY.set()
+
+
+class ReloadHelper:
+    def __init__(self, page):
+        self.page = page
+
+    def page_changed(self):
+        _page_changed(self.page)
+
+        return TRANSLATIONS, CATEGORIES, PAGES
+
+    def load_metadata(self):
+        start = time.time()
+        log.info("Loading metadata (this can take a while the first run) ...")
+
+        TRANSLATIONS.clear()
+        CATEGORIES.clear()
+        PAGES.clear()
+
+        if os.path.exists(CACHE_FILENAME):
+            with open(CACHE_FILENAME, "r") as fp:
+                payload = json.loads(fp.read())
+                TRANSLATIONS.update(payload["translations"])
+                CATEGORIES.update(payload["categories"])
+                PAGES.update(payload["pages"])
+
+            # After JSON dumps/loads, set became lists; make sure all sets are sets again.
+            for page in PAGES:
+                PAGES[page]["dependencies"] = set(PAGES[page]["dependencies"])
+
+        # Ensure no file is scanned more than once.
+        notified = set()
+        # Keep track of which pages we have seen.
+        pages_seen = set()
+        # Scan all folders with mediawiki files.
+        for subfolder in ("Page", "Template", "Category"):
+            pages_seen.update(_scan_folder(f"{subfolder}", notified))
+
+        # If we come from cache, validate that no file got removed; we should
+        # forget about those.
+        pages_known = set(page for page in PAGES if PAGES[page]["digest"])
+        for page in pages_seen:
+            if page in pages_known:
+                pages_known.remove(page)
+        for page in pages_known:
+            _forget_page(page)
+
+        # Sort all translations and categories; makes it easier for the render.
+        for translation in TRANSLATIONS:
+            TRANSLATIONS[translation] = sorted(TRANSLATIONS[translation], key=lambda name: (name.find("en/") < 0, name))
+        for category in CATEGORIES:
+            CATEGORIES[category] = sorted(CATEGORIES[category])
+
+        with open(CACHE_FILENAME, "w") as fp:
+            fp.write(
+                json.dumps(
+                    {
+                        "translations": TRANSLATIONS,
+                        "categories": CATEGORIES,
+                        "pages": PAGES,
+                    },
+                    default=json_set_serialize,
+                )
             )
-        )
+
+        log.info(f"Loading metadata done; took {time.time() - start:.2f} seconds")
+        return TRANSLATIONS, CATEGORIES, PAGES


### PR DESCRIPTION
This means that is someone saves a page that takes 10+ seconds
to reanalyze the metadata, it no longer blocks the webinterface.
Instead, the update is delayed heavily, so someone could add
a category that only shows up seconds later. That is the trade-off
here.