### PR TITLE
Fix: make the instructions for Docker by default a bit quicker after first run

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
 __pycache__/
 *.pyc
+/.cache_metadata.json
 /.env
 /.git/**
 /data/
+/cache/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 __pycache__/
 *.pyc
+/.cache_metadata.json
 .coverage
 /.env
 /data/
+/cache/

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN pip freeze 2>/dev/null > requirements.installed \
 COPY static /code/static
 COPY templates /code/templates
 COPY truewiki /code/truewiki
+RUN mkdir /data
 
 ENTRYPOINT ["python", "-m", "truewiki"]
-CMD ["--bind", "0.0.0.0", "--storage", "local", "--user", "developer"]
+CMD ["--bind", "0.0.0.0", "--storage", "local", "--storage-folder", "/data", "--cache-metadata-file", "/cache/metadata.json", "--user", "developer"]

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This will start the server on port 8000 for you to work with locally.
 
 ```bash
 docker build -t truebrain/truewiki:local .
-docker run --rm -p 127.0.0.1:8000:80 -v "`pwd`/data:/code/data" truebrain/truewiki:local
+docker run --rm -p 127.0.0.1:8000:80 -v "`pwd`/data:/data" -v "`pwd`/cache:/cache" truebrain/truewiki:local
 ```
 
 ## Why Yet-Another-Wiki-Server

--- a/truewiki/storage/local.py
+++ b/truewiki/storage/local.py
@@ -28,7 +28,7 @@ class Storage:
     "--storage-folder",
     help="Folder to use for storage.",
     type=click.Path(dir_okay=True, file_okay=False),
-    default="data",
+    default="./data",
     show_default=True,
 )
 def click_storage_local(storage_folder):


### PR DESCRIPTION
It now sets the cache file for metadata in a folder that is strongly
suggested to volume mount. This means a second start is a lot faster
(from 200s to 0.1s).