### PR TITLE
Fix: remember the page-name when previewing

### DIFF
--- a/templates/Edit.mediawiki
+++ b/templates/Edit.mediawiki
@@ -73,10 +73,10 @@
             <form method="post">
 
             {{#if:{{{has_used_on_pages|}}}|
-            <input type="text" value="{{FULLPAGENAME}}" style="width: 100%;" disabled />
+            <input type="text" value="{{{new_page}}}" style="width: 100%;" disabled />
             <span id="no-rename">Pages cannot be renamed if they are used by other pages. Still want to rename? Create a <a href="{{{repository_url}}}/pulls" target="_new">Pull Request</a> or <a href="{{{repository_url}}}/issues" target="_new">Issue</a>.</span>
             |
-            <input type="text" name="page" value="{{FULLPAGENAME}}" style="width: 100%;" />
+            <input type="text" name="page" value="{{{new_page}}}" style="width: 100%;" />
             }}
 
             <textarea name="content" style="width: 100%;" rows=50>{{page}}</textarea>

--- a/truewiki/views/edit.py
+++ b/truewiki/views/edit.py
@@ -134,5 +134,5 @@ def view(user, page: str) -> web.Response:
             f'Page name "{page}" conflicts with "{correct_page}". Did you mean to edit [[{correct_page}]]?',
         )
 
-    body = source.create_body(wiki_page, user, "Edit")
+    body = source.create_body(wiki_page, user, "Edit", new_page=page)
     return web.Response(body=body, content_type="text/html")

--- a/truewiki/views/preview.py
+++ b/truewiki/views/preview.py
@@ -7,13 +7,10 @@ from . import (
 from ..wiki_page import WikiPage
 
 
-def view(user, page: str, body: str) -> web.Response:
-    if page.endswith("/"):
-        page += "Main Page"
-
+def view(user, page: str, new_page: str, body: str) -> web.Response:
     wiki_page = WikiPage(page)
     if not wiki_page.page_is_valid(page):
         return error.view(user, page, "Error 404 - File not found")
 
-    body = source.create_body(wiki_page, user, "Edit", preview=body)
+    body = source.create_body(wiki_page, user, "Edit", preview=body, new_page=new_page)
     return web.Response(body=body, content_type="text/html")

--- a/truewiki/views/source.py
+++ b/truewiki/views/source.py
@@ -17,10 +17,10 @@ from ..wiki_page import (
 from ..wrapper import wrap_page
 
 
-def create_body(wiki_page, user, wrapper, preview=None) -> str:
+def create_body(wiki_page, user, wrapper, preview=None, new_page=None) -> str:
     ondisk_name = wiki_page.page_ondisk_name(wiki_page.page)
 
-    if preview:
+    if preview is not None:
         body = preview
         wtp = wiki_page.prepare(preview)
         content = wiki_page.render_page(wtp)
@@ -67,7 +67,8 @@ def create_body(wiki_page, user, wrapper, preview=None) -> str:
         "has_errors": "1" if errors else "",
         "display_name": user.display_name if user else "",
         "user_settings_url": user.get_settings_url() if user else "",
-        "is_preview": "1" if preview else "",
+        "is_preview": "1" if preview is not None else "",
+        "new_page": new_page if new_page else "",
     }
 
     templates["language"] = wiki_page.add_language(wiki_page.page)

--- a/truewiki/web_routes.py
+++ b/truewiki/web_routes.py
@@ -98,7 +98,7 @@ async def edit_page_post(request):
         return edit.save(user, page, payload.get("page", page), payload["content"])
 
     if "preview" in payload:
-        return preview.view(user, page, payload["content"])
+        return preview.view(user, page, payload.get("page", page), payload["content"])
 
     raise web.HTTPNotFound()
 


### PR DESCRIPTION
Additionally, do not sneak in "Main Page" when pressing preview;
it is annoying and unnneeded.