### PR TITLE
Add: render /License with the content of LICENSE.mediawiki

### DIFF
--- a/templates/Edit.mediawiki
+++ b/templates/Edit.mediawiki
@@ -110,7 +110,7 @@
                 <a href="https://github.com/TrueBrain/TrueWiki">Powered by TrueWiki</a>
             </div>
             <div id="content-bottom-copyright">
-                Content is available under GNU Free Documentation License
+                Content is available under <a href="/License">GNU Free Documentation License</a>
             </div>
         </footer>
     </body>

--- a/templates/Error.mediawiki
+++ b/templates/Error.mediawiki
@@ -48,7 +48,7 @@
                 <a href="https://github.com/TrueBrain/TrueWiki">Powered by TrueWiki</a>
             </div>
             <div id="content-bottom-copyright">
-                Content is available under GNU Free Documentation License
+                Content is available under <a href="/License">GNU Free Documentation License</a>
             </div>
         </footer>
     </body>

--- a/templates/Login.mediawiki
+++ b/templates/Login.mediawiki
@@ -48,7 +48,7 @@
                 <a href="https://github.com/TrueBrain/TrueWiki">Powered by TrueWiki</a>
             </div>
             <div id="content-bottom-copyright">
-                Content is available under GNU Free Documentation License
+                Content is available under <a href="/License">GNU Free Documentation License</a>
             </div>
         </footer>
     </body>

--- a/templates/Page.mediawiki
+++ b/templates/Page.mediawiki
@@ -88,7 +88,7 @@
                 <a href="https://github.com/TrueBrain/TrueWiki">Powered by TrueWiki</a>
             </div>
             <div id="content-bottom-copyright">
-                Content is available under GNU Free Documentation License
+                Content is available under <a href="/License">GNU Free Documentation License</a>
             </div>
         </footer>
     </body>

--- a/templates/Source.mediawiki
+++ b/templates/Source.mediawiki
@@ -78,7 +78,7 @@
                 <a href="https://github.com/TrueBrain/TrueWiki">Powered by TrueWiki</a>
             </div>
             <div id="content-bottom-copyright">
-                Content is available under GNU Free Documentation License
+                Content is available under <a href="/License">GNU Free Documentation License</a>
             </div>
         </footer>
     </body>

--- a/truewiki/content/breadcrumb.py
+++ b/truewiki/content/breadcrumb.py
@@ -5,6 +5,9 @@ from ..wiki_page import WikiPage
 
 
 def create(page):
+    if not page:
+        return '<li class="crumb"><a href="/">OpenTTD\'s Wiki</a></li>'
+
     spage = page.split("/")
 
     breadcrumbs = []

--- a/truewiki/views/license.py
+++ b/truewiki/views/license.py
@@ -1,0 +1,27 @@
+from aiohttp import web
+
+from .. import singleton
+from ..content import breadcrumb
+from ..wiki_page import WikiPage
+from ..wrapper import wrap_page
+
+
+def view(user) -> web.Response:
+    body = singleton.STORAGE.file_read("LICENSE.mediawiki")
+
+    wiki_page = WikiPage("License")
+    wtp = wiki_page.prepare(body)
+
+    templates = {
+        "content": wiki_page.render_page(wtp),
+        "breadcrumbs": breadcrumb.create(""),
+        "language": "",
+        "footer": "",
+    }
+    variables = {
+        "display_name": user.display_name if user else "",
+        "user_settings_url": user.get_settings_url() if user else "",
+    }
+
+    body = wrap_page("License", "Page", variables, templates)
+    return web.Response(body=body, content_type="text/html")

--- a/truewiki/web_routes.py
+++ b/truewiki/web_routes.py
@@ -9,6 +9,7 @@ from . import singleton
 from .metadata import load_metadata
 from .views import (
     edit,
+    license as license_page,
     login,
     source,
     page as view_page,
@@ -64,6 +65,12 @@ async def reload(request):
 @routes.get("/healthz")
 async def healthz_handler(request):
     return web.HTTPOk()
+
+
+@routes.get("/License")
+async def license(request):
+    user = get_user_by_bearer(request.cookies.get(SESSION_COOKIE_NAME))
+    return license_page.view(user)
 
 
 @routes.get("/edit/{page:.*}")

--- a/truewiki/wiki_page.py
+++ b/truewiki/wiki_page.py
@@ -24,6 +24,10 @@ class WikiPage(Page):
         return NAMESPACES.get(namespace, NAMESPACE_DEFAULT_PAGE).page_load(page)
 
     def page_exists(self, page: str) -> bool:
+        # "License" is a special page that always exists.
+        if page == "License":
+            return True
+
         namespace = page.split("/")[0]
         return NAMESPACES.get(namespace, NAMESPACE_DEFAULT_PAGE).page_exists(page)
 
@@ -43,6 +47,10 @@ class WikiPage(Page):
         return NAMESPACES.get(namespace, NAMESPACE_DEFAULT_PAGE).page_get_correct_case(page)
 
     def has_source(self, page: str) -> bool:
+        # "License" is a special page, of which we never show the source.
+        if page == "License":
+            return False
+
         namespace = page.split("/")[0]
         return NAMESPACES.get(namespace, NAMESPACE_DEFAULT_PAGE).has_source(page)
 
@@ -59,6 +67,10 @@ class WikiPage(Page):
         return NAMESPACES.get(namespace, NAMESPACE_DEFAULT_PAGE).get_used_on_pages(self.page)
 
     def clean_title(self, title: str) -> str:
+        # "License" is a special page that is called "License"
+        if title == "License":
+            return "License"
+
         namespace = title.split("/")[0]
         return NAMESPACES.get(namespace, NAMESPACE_DEFAULT_PAGE).clean_title(self.page, title)
 


### PR DESCRIPTION
This is a special-case URL, as we wouldn't want anyone to
translate it, ideally it should be in the root of the data-folder,
and nobody is allowed to edit it. This is all made possible by
making the page a special case.