### PR TITLE
Fix: also strip \r from preview render

### DIFF
--- a/truewiki/views/edit.py
+++ b/truewiki/views/edit.py
@@ -159,7 +159,7 @@ def save(user, old_page: str, new_page: str, content: str, payload) -> web.Respo
     # Make sure the folder exists.
     singleton.STORAGE.dir_make(new_dirname)
     # Write the new source.
-    singleton.STORAGE.file_write(new_filename, content.replace("\r", ""))
+    singleton.STORAGE.file_write(new_filename, content)
 
     # Inform the namespace of the edit.
     wiki_page.edit_callback(old_page, new_page, payload, execute=True)

--- a/truewiki/web_routes.py
+++ b/truewiki/web_routes.py
@@ -103,12 +103,13 @@ async def edit_page_post(request):
     payload = await request.post()
     if "content" not in payload:
         raise web.HTTPNotFound()
+    content = payload["content"].replace("\r", "")
 
     if "save" in payload:
-        return edit.save(user, page, payload.get("page", page), payload["content"], payload)
+        return edit.save(user, page, payload.get("page", page), content, payload)
 
     if "preview" in payload:
-        return preview.view(user, page, payload.get("page", page), payload["content"])
+        return preview.view(user, page, payload.get("page", page), content)
 
     raise web.HTTPNotFound()
 


### PR DESCRIPTION
Otherwise wikitexthtml fails to detect \n\n, to insert `<p>`'s.