### PR TITLE
Fix #48: report errors about wrong page names within the edit page

### DIFF
--- a/templates/Edit.mediawiki
+++ b/templates/Edit.mediawiki
@@ -46,8 +46,12 @@
             </ul>
         </nav>
         <main>
+            {{#if:{{{page_error|}}}|
+            <h3><font color="red">Error saving page</font></h3>
+                <ul><li>{{{page_error|}}}</li></ul>
+            }}
             {{#if:{{{has_errors|}}}|
-            <h3>Errors</h3>
+            <h3>Problems</h3>
             <ul>
                 {{errors}}
             </ul>

--- a/templates/Page.mediawiki
+++ b/templates/Page.mediawiki
@@ -32,7 +32,7 @@
                     <a href="/edit/{{urlencode:{{FULLPAGENAME}}}}">
                         {{#if: {{{does_exist|}}}|Edit Page|Create Page}}
                         {{#if: {{{errors|}}}|
-                            <span class="badge" title="There were {{{errors}}} errors while rendering this page">{{{errors}}}</span>
+                            <span class="badge" title="There were {{{errors}}} problems while rendering this page">{{{errors}}}</span>
                         }}
                     </a>
                     |
@@ -40,7 +40,7 @@
                         <a href="/{{urlencode:{{FULLPAGENAME}}}}.mediawiki">
                         View Source
                         {{#if: {{{errors|}}}|
-                            <span class="badge" title="There were {{{errors}}} errors while rendering this page">{{{errors}}}</span>
+                            <span class="badge" title="There were {{{errors}}} problems while rendering this page">{{{errors}}}</span>
                         }}
                         </a>
                     }}

--- a/templates/Source.mediawiki
+++ b/templates/Source.mediawiki
@@ -47,7 +47,7 @@
         </nav>
         <main>
             {{#if:{{{has_errors|}}}|
-            <h3>Errors</h3>
+            <h3>Problems</h3>
             <ul>
                 {{errors}}
             </ul>

--- a/truewiki/views/edit.py
+++ b/truewiki/views/edit.py
@@ -17,23 +17,21 @@ from ..wiki_page import WikiPage
 def save(user, old_page: str, new_page: str, content: str, payload) -> web.Response:
     wiki_page = WikiPage(old_page)
     page_error = wiki_page.page_is_valid(old_page, is_new_page=True)
-    if not page_error:
+    if page_error:
+        return error.view(user, old_page, page_error)
+
+    if new_page.endswith("/"):
+        page_error = (
+            f'Page name "{new_page}" cannot end with a "/". If you meant the main page, please add "Main Page". '
+            'The name of the page "Main Page" cannot be translated, and is always written in English, '
+            "no matter the language you are in. The content of course can be translated."
+        )
+    else:
         page_error = wiki_page.page_is_valid(new_page, is_new_page=True)
-    if not page_error:
-        if new_page.endswith("/"):
-            page_error = (
-                f'Page name "{new_page}" cannot end with a "/". If you meant the main page, please add "Main Page". '
-                'The name of the page "Main Page" cannot be translated, and is always written in English, '
-                "no matter the language you are in. The content of course can be translated."
-            )
 
     if page_error:
-        return error.view(
-            user,
-            old_page,
-            page_error,
-            status=401,
-        )
+        body = source.create_body(wiki_page, user, "Edit", new_page=new_page, page_error=page_error)
+        return web.Response(body=body, content_type="text/html")
 
     # If the old page doesn't exist, this creates a page. But it is possible
     # that this is done from an old page with a different name. Make sure the

--- a/truewiki/views/preview.py
+++ b/truewiki/views/preview.py
@@ -7,11 +7,20 @@ from . import (
 from ..wiki_page import WikiPage
 
 
-def view(user, page: str, new_page: str, body: str) -> web.Response:
-    wiki_page = WikiPage(page)
-    page_error = wiki_page.page_is_valid(page)
+def view(user, old_page: str, new_page: str, body: str) -> web.Response:
+    wiki_page = WikiPage(old_page)
+    page_error = wiki_page.page_is_valid(old_page, is_new_page=True)
     if page_error:
-        return error.view(user, page, page_error)
+        return error.view(user, old_page, page_error)
 
-    body = source.create_body(wiki_page, user, "Edit", preview=body, new_page=new_page)
+    if new_page.endswith("/"):
+        page_error = (
+            f'Page name "{new_page}" cannot end with a "/". If you meant the main page, please add "Main Page". '
+            'The name of the page "Main Page" cannot be translated, and is always written in English, '
+            "no matter the language you are in. The content of course can be translated."
+        )
+    else:
+        page_error = wiki_page.page_is_valid(new_page, is_new_page=True)
+
+    body = source.create_body(wiki_page, user, "Edit", preview=body, new_page=new_page, page_error=page_error)
     return web.Response(body=body, content_type="text/html")

--- a/truewiki/views/source.py
+++ b/truewiki/views/source.py
@@ -14,7 +14,7 @@ from ..wiki_page import (
 from ..wrapper import wrap_page
 
 
-def create_body(wiki_page: WikiPage, user, wrapper, preview=None, new_page=None) -> str:
+def create_body(wiki_page: WikiPage, user, wrapper, preview=None, new_page=None, page_error=None) -> str:
     ondisk_name = wiki_page.page_ondisk_name(wiki_page.page)
 
     if preview is not None:
@@ -75,6 +75,7 @@ def create_body(wiki_page: WikiPage, user, wrapper, preview=None, new_page=None)
         "user_settings_url": user.get_settings_url() if user else "",
         "is_preview": "1" if preview is not None else "",
         "new_page": html.escape(new_page) if new_page else "",
+        "page_error": page_error if page_error else "",
     }
 
     templates["language"] = wiki_page.add_language(wiki_page.page)


### PR DESCRIPTION
This should make it easier to see and fix any page name error.