### PR TITLE
Add: move all git operations into another process

### DIFF
--- a/truewiki/metadata.py
+++ b/truewiki/metadata.py
@@ -43,6 +43,8 @@ TRANSLATIONS = defaultdict(list)
 RELOAD_BUSY = asyncio.Event()
 RELOAD_BUSY.set()
 
+METADATA_READY = asyncio.Event()
+
 
 def translation_callback(wtp, wiki_page, page):
     for wikilink in wtp.wikilinks:
@@ -203,6 +205,8 @@ def _scan_folder(folder, notified=None):
 
 
 def load_metadata():
+    METADATA_READY.clear()
+
     loop = asyncio.get_event_loop()
     loop.create_task(out_of_process("load_metadata", None))
 
@@ -238,6 +242,9 @@ async def out_of_process(func, pages):
             ) = await task
     finally:
         RELOAD_BUSY.set()
+
+    if func == "load_metadata":
+        METADATA_READY.set()
 
 
 class ReloadHelper:

--- a/truewiki/storage/local.py
+++ b/truewiki/storage/local.py
@@ -5,6 +5,8 @@ import os
 from openttd_helpers import click_helper
 from typing import List
 
+from .. import metadata
+
 STORAGE_FOLDER = None
 
 
@@ -16,7 +18,7 @@ class Storage:
         pass
 
     def reload(self):
-        pass
+        metadata.load_metadata()
 
     def commit(self, user, commit_message):
         pass

--- a/truewiki/web_routes.py
+++ b/truewiki/web_routes.py
@@ -7,7 +7,6 @@ from aiohttp import web
 from openttd_helpers import click_helper
 
 from . import singleton
-from .metadata import load_metadata
 from .views import (
     edit,
     license as license_page,
@@ -89,7 +88,6 @@ async def reload(request):
         return web.HTTPNotFound()
 
     singleton.STORAGE.reload()
-    load_metadata()
 
     return web.HTTPNoContent()
 


### PR DESCRIPTION
This drasticly speeds up the interface from a user-perspective,
and this is a fancy way of working around the GIL. Ideally we would
use a Git library that is async, which would also resolve this
issue, but with GitPython we are basically 4+ seconds waiting for
"git push" to finish. As that locks the GIL, no other request can
be handled while this is going on.

By moving the git operations to their own process, the main process
can safely continue to serve requests while in the background
git and GitHub are being updated. This is relative safe, as the
application itself doesn't care about git and/or GitHub. Locking
around the use of the out-of-process-git should prevent two
processes trying to access git and/or GitHub.

It is possible that if many people edit pages rapidly, that the
queue of things to commit gets long, and that commits start to
overlap. For example:
 create page -> modify -> modify -> modify
All within 5 seconds, will most likely create only two commits,
one with the create, and the rest with all the modifications
in one. It is, however, rather unlikely humans can go through
the interface within 5 seconds to make sane modifications. So
this is considered an accepted edge-case.