### PR TITLE
Fix: language-folders don't have to exist in namespaces

### DIFF
--- a/truewiki/namespaces/category/namespace.py
+++ b/truewiki/namespaces/category/namespace.py
@@ -101,7 +101,7 @@ class Namespace(base.Namespace):
         if len(spage) < 3:
             return f'Page name "{page}" is missing a language code.'
         # The language should already exist.
-        if not singleton.STORAGE.dir_exists(f"Category/{spage[1]}"):
+        if spage[1] not in metadata.LANGUAGES:
             return f'Page name "{page}" is in language "{spage[1]}" that does not exist.'
 
         return None

--- a/truewiki/namespaces/file/namespace.py
+++ b/truewiki/namespaces/file/namespace.py
@@ -88,7 +88,7 @@ class Namespace(base.Namespace):
         if len(spage) < 3:
             return f'Page name "{page}" is missing a language code.'
         # The language should already exist.
-        if not singleton.STORAGE.dir_exists(f"File/{spage[1]}"):
+        if spage[1] not in metadata.LANGUAGES:
             return f'Page name "{page}" is in language "{spage[1]}" that does not exist.'
 
         if not cls._is_language_root(page) and not cls._is_root_of_folder(page):

--- a/truewiki/namespaces/folder/namespace.py
+++ b/truewiki/namespaces/folder/namespace.py
@@ -5,6 +5,7 @@ from typing import Optional
 from . import content
 from .. import base
 from ... import (
+    metadata,
     singleton,
     wiki_page,
 )
@@ -72,8 +73,8 @@ class Namespace(base.Namespace):
         if len(spage) < 4:
             return f'Page name "{page}" is missing a namespace and/or language code.'
         # The namespace and language should already exist.
-        if not singleton.STORAGE.dir_exists(f"{spage[1]}/{spage[2]}"):
-            return f'Page name "{page}" is in language "{spage[2]}" that does not exist for namespace "{spage[1]}".'
+        if spage[2] not in metadata.LANGUAGES:
+            return f'Page name "{page}" is in language "{spage[2]}" that does not exist.'
         return None
 
     @staticmethod

--- a/truewiki/namespaces/page/namespace.py
+++ b/truewiki/namespaces/page/namespace.py
@@ -55,7 +55,7 @@ class Namespace(base.Namespace):
         if len(spage) < 2:
             return f'Page name "{page}" is missing a language code.'
         # The language should already exist.
-        if not singleton.STORAGE.dir_exists(f"Page/{spage[0]}"):
+        if spage[0] not in metadata.LANGUAGES:
             return f'Page name "{page}" is in language "{spage[0]}" that does not exist.'
 
         return None

--- a/truewiki/namespaces/template/namespace.py
+++ b/truewiki/namespaces/template/namespace.py
@@ -89,7 +89,7 @@ class Namespace(base.Namespace):
         if len(spage) < 3:
             return f'Page name "{page}" is missing a language code.'
         # The language should already exist.
-        if not singleton.STORAGE.dir_exists(f"Template/{spage[1]}"):
+        if spage[1] not in metadata.LANGUAGES:
             return f'Page name "{page}" is in language "{spage[1]}" that does not exist.'
 
         return None


### PR DESCRIPTION
If they do not, allow the creation of them by making them linkable.
At least 1 namespace does need to know the language, just to
prevent people from making random languages because they were
feeling like it.