### PR TITLE
Add: cache rendered pages on disk, and serve from there on cache-hit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,4 +47,4 @@ COPY truewiki /code/truewiki
 RUN mkdir /data
 
 ENTRYPOINT ["python", "-m", "truewiki"]
-CMD ["--bind", "0.0.0.0", "--storage", "local", "--storage-folder", "/data", "--cache-metadata-file", "/cache/metadata.json", "--user", "developer"]
+CMD ["--bind", "0.0.0.0", "--storage", "local", "--storage-folder", "/data", "--cache-metadata-file", "/cache/metadata.json", "--cache-page-folder", "/cache/pages", "--user", "developer"]

--- a/truewiki/__main__.py
+++ b/truewiki/__main__.py
@@ -24,6 +24,7 @@ from .user_session import (
     remove_session_cookie,
     SESSION_COOKIE_NAME,
 )
+from .views.page import click_page
 from .web_routes import (
     click_web_routes,
     routes,
@@ -100,6 +101,7 @@ async def wait_for_storage():
 @click_storage_github
 @click_user_session
 @click_user_github
+@click_page
 @click.option("--validate-all", help="Validate all mediawiki files and report all errors", is_flag=True)
 def main(bind, port, storage, validate_all):
     log.info("Reload storage ..")


### PR DESCRIPTION
This uses the same method as we use to detect if the page is a
cache hit when if-modified-since is sent.
For OpenTTD, the total cache-on-disk would be ~150MB, for 10k
pages.