### PR TITLE
Fix: only try to load a cache file from disk if the file exists

### DIFF
--- a/truewiki/views/page.py
+++ b/truewiki/views/page.py
@@ -73,7 +73,7 @@ def view(user, page: str, if_modified_since) -> web.Response:
             # We already rendered this page before. If the browser has it in his
             # cache, he can simply reuse that if we haven't rendered since.
             response = web.HTTPNotModified()
-        elif not user and cache_filename:
+        elif not user and cache_filename and os.path.exists(cache_filename):
             # We already rendered this page to disk. Serve from there.
             with open(cache_filename) as fp:
                 body = fp.read()


### PR DESCRIPTION
This could happen if the first time a page was loaded, was done
by someone who was logged in. This does update LAST_TIME_RENDERED
for browser if-modified-since caching, but does not write the
file to disk. If a non-logged-in user visit the page after, the
page is not on disk.