### PR TITLE
Fix #87: allow spaces before and after the page in wikilink

### DIFF
--- a/truewiki/namespaces/category/wikilink.py
+++ b/truewiki/namespaces/category/wikilink.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 def replace(instance: WikiPage, wikilink: wikitextparser.WikiLink):
     # This indicates that the page belongs to this category. We update
     # the WikiPage to indicate this, and otherwise remove the WikiLink.
-    category = wikilink.target[len("category:") :]
+    category = wikilink.target[len("category:") :].strip()
 
     error = instance.page_is_valid(f"Category/{category}")
     if error:
@@ -24,7 +24,7 @@ def replace(instance: WikiPage, wikilink: wikitextparser.WikiLink):
 
 
 def link(instance: WikiPage, wikilink: wikitextparser.WikiLink):
-    target = wikilink.target[len(":category:") :]
+    target = wikilink.target[len(":category:") :].strip()
 
     # Generate a link to the language root, which will list all categories
     # of that language.

--- a/truewiki/namespaces/file/wikilink.py
+++ b/truewiki/namespaces/file/wikilink.py
@@ -12,8 +12,7 @@ log = logging.getLogger(__name__)
 
 
 def link_file(instance: WikiPage, wikilink: wikitextparser.WikiLink):
-    target = wikilink.target
-    target = target[len(":file:") :]
+    target = wikilink.target[len(":file:") :].strip()
 
     # Generate a link to the language root, which will list all templates
     # of that language.
@@ -27,7 +26,7 @@ def link_file(instance: WikiPage, wikilink: wikitextparser.WikiLink):
 
 def link_media(instance: WikiPage, wikilink: wikitextparser.WikiLink):
     target = wikilink.target
-    target = target[len("media:") :]
+    target = target[len("media:") :].strip()
 
     url = f"File/{target}"
 

--- a/truewiki/namespaces/folder/wikilink.py
+++ b/truewiki/namespaces/folder/wikilink.py
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 
 
 def link(instance: WikiPage, wikilink: wikitextparser.WikiLink):
-    target = wikilink.target[len(":folder:") :]
+    target = wikilink.target[len(":folder:") :].strip()
 
     # As we are browsing folders, [[Folder:en]] and [[Folder:en/]] are
     # identical in meaning.

--- a/truewiki/namespaces/template/wikilink.py
+++ b/truewiki/namespaces/template/wikilink.py
@@ -13,7 +13,7 @@ def link_and_replace(instance: WikiPage, wikilink: wikitextparser.WikiLink):
 
     if target.startswith(":"):
         target = target[1:]
-    target = target[len("template:") :]
+    target = target[len("template:") :].strip()
 
     # Generate a link to the language root, which will list all templates
     # of that language.

--- a/truewiki/namespaces/translation/wikilink.py
+++ b/truewiki/namespaces/translation/wikilink.py
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 
 
 def replace(instance: WikiPage, wikilink: wikitextparser.WikiLink):
-    page = wikilink.target[len("translation:") :]
+    page = wikilink.target[len("translation:") :].strip()
 
     error = instance.page_is_valid(f"{page}")
     if error:


### PR DESCRIPTION
[[:Folder:en/Bla | Bla]] for example now works.