### PR TITLE
Add: search-bar that uses DuckDuckGo to search the wiki

### DIFF
--- a/static/truewiki/truewiki.css
+++ b/static/truewiki/truewiki.css
@@ -490,7 +490,7 @@ header {
 #review-access {
     position: absolute;
     right: 30px;
-    top: 10px;
+    top: 70px;
 }
 #review-access a {
     color: #aaa;
@@ -503,4 +503,47 @@ header {
     display: block;
     font-size: 70%;
     margin: -4px 0 4px 0;
+}
+
+#search {
+    position: absolute;
+    right: 30px;
+    top: 10px;
+}
+#search input[type=text] {
+    width: 150px;
+}
+
+#search-submit {
+    display: inline-block;
+    position: absolute;
+    right: 0px;
+}
+#search-submit input {
+    background-color: white;
+    border: 0;
+    border-left: 1px solid #aaa;
+    height: 20px;
+    margin: 1px 1px 0 0;
+    width: 20px;
+}
+#search-submit:hover input {
+    background-color: #aaa;
+}
+#search-submit div {
+    display: inline-block;
+    pointer-events: none;
+    position: absolute;
+    right: 1px;
+    top: -1px;
+    transform: rotate(45deg);
+}
+#search-submit div::after {
+    color: #D52D2D;
+    content: "⚲";
+    font-size: 18px;
+    font-weight: bold;
+    left: -4px;
+    position: relative;
+    top: 4px;
 }

--- a/templates/Edit.mediawiki
+++ b/templates/Edit.mediawiki
@@ -20,6 +20,20 @@
                 <a href="{{{user_settings_url}}}">Review access</a>
             </div>
             }}
+            {{#if: {{{has_search|}}}|
+            <div id="search">
+                <form action="/search" target="_new">
+                    {{#if: {{{language|}}}|
+                    <input type="hidden" name="language" value="{{{language}}}" />
+                    }}
+                    <input type="text" autocomplete="off" name="query" value="" placeholder="Search wiki" />
+                    <div id="search-submit">
+                        <input type="submit" value="" />
+                        <div></div>
+                    </div>
+                </form>
+            </div>
+            }}
         </header>
         <nav>
             <ul id="navigation-bar">

--- a/templates/Error.mediawiki
+++ b/templates/Error.mediawiki
@@ -15,6 +15,20 @@
                 Error
             </div>
             {{{html_header}}}
+            {{#if: {{{has_search|}}}|
+            <div id="search">
+                <form action="/search" target="_new">
+                    {{#if: {{{language|}}}|
+                    <input type="hidden" name="language" value="{{{language}}}" />
+                    }}
+                    <input type="text" autocomplete="off" name="query" value="" placeholder="Search wiki" />
+                    <div id="search-submit">
+                        <input type="submit" value="" />
+                        <div></div>
+                    </div>
+                </form>
+            </div>
+            }}
         </header>
         <nav>
             <ul id="navigation-bar">

--- a/templates/Login.mediawiki
+++ b/templates/Login.mediawiki
@@ -20,6 +20,20 @@
                 <a href="{{{user_settings_url}}}">Review access</a>
             </div>
             }}
+            {{#if: {{{has_search|}}}|
+            <div id="search">
+                <form action="/search" target="_new">
+                    {{#if: {{{language|}}}|
+                    <input type="hidden" name="language" value="{{{language}}}" />
+                    }}
+                    <input type="text" autocomplete="off" name="query" value="" placeholder="Search wiki" />
+                    <div id="search-submit">
+                        <input type="submit" value="" />
+                        <div></div>
+                    </div>
+                </form>
+            </div>
+            }}
         </header>
         <nav>
             <ul id="navigation-bar" class="right">

--- a/templates/Page.mediawiki
+++ b/templates/Page.mediawiki
@@ -19,6 +19,20 @@
                 <a href="{{{user_settings_url}}}">Review access</a>
             </div>
             }}
+            {{#if: {{{has_search|}}}|
+            <div id="search">
+                <form action="/search" target="_new">
+                    {{#if: {{{language|}}}|
+                    <input type="hidden" name="language" value="{{{language}}}" />
+                    }}
+                    <input type="text" autocomplete="off" name="query" value="" placeholder="Search wiki" />
+                    <div id="search-submit">
+                        <input type="submit" value="" />
+                        <div></div>
+                    </div>
+                </form>
+            </div>
+            }}
         </header>
         <nav>
             <ul id="navigation-bar">

--- a/templates/Source.mediawiki
+++ b/templates/Source.mediawiki
@@ -20,6 +20,20 @@
                 <a href="{{{user_settings_url}}}">Review access</a>
             </div>
             }}
+            {{#if: {{{has_search|}}}|
+            <div id="search">
+                <form action="/search" target="_new">
+                    {{#if: {{{language|}}}|
+                    <input type="hidden" name="language" value="{{{language}}}" />
+                    }}
+                    <input type="text" autocomplete="off" name="query" value="" placeholder="Search wiki" />
+                    <div id="search-submit">
+                        <input type="submit" value="" />
+                        <div></div>
+                    </div>
+                </form>
+            </div>
+            }}
         </header>
         <nav>
             <ul id="navigation-bar">

--- a/truewiki/namespaces/base.py
+++ b/truewiki/namespaces/base.py
@@ -95,6 +95,10 @@ class Namespace:
         return metadata.PAGES_LC.get(page.lower(), page)
 
     @staticmethod
+    def page_get_language(page: str) -> str:
+        return None
+
+    @staticmethod
     def get_create_page_name(page: str) -> str:
         return ""
 

--- a/truewiki/namespaces/category/namespace.py
+++ b/truewiki/namespaces/category/namespace.py
@@ -107,6 +107,15 @@ class Namespace(base.Namespace):
         return None
 
     @classmethod
+    def page_get_language(cls, page: str) -> Optional[str]:
+        assert page.startswith("Category/")
+
+        if cls._is_root(page):
+            return None
+
+        return page.split("/")[1]
+
+    @classmethod
     def has_source(cls, page: str) -> bool:
         return not cls._is_root(page) and not cls._is_root_of_folder(page)
 

--- a/truewiki/namespaces/file/namespace.py
+++ b/truewiki/namespaces/file/namespace.py
@@ -97,6 +97,15 @@ class Namespace(base.Namespace):
 
         return None
 
+    @classmethod
+    def page_get_language(cls, page: str) -> Optional[str]:
+        assert page.startswith("File/")
+
+        if cls._is_root(page):
+            return None
+
+        return page.split("/")[1]
+
     @staticmethod
     def get_used_on_pages(page: str) -> list:
         assert page.startswith("File/")

--- a/truewiki/namespaces/folder/namespace.py
+++ b/truewiki/namespaces/folder/namespace.py
@@ -81,6 +81,17 @@ class Namespace(base.Namespace):
     def page_ondisk_name(page: str) -> str:
         return None
 
+    @classmethod
+    def page_get_language(cls, page: str) -> Optional[str]:
+        assert page.startswith("Folder/")
+
+        if cls._is_root(page):
+            return None
+        if cls._is_namespace_root(page):
+            return None
+
+        return page.split("/")[2]
+
     @staticmethod
     def get_used_on_pages(page: str) -> list:
         return []

--- a/truewiki/namespaces/page/namespace.py
+++ b/truewiki/namespaces/page/namespace.py
@@ -68,6 +68,12 @@ class Namespace(base.Namespace):
             correct_page = correct_page[len("Page/") :]
         return correct_page
 
+    @classmethod
+    def page_get_language(cls, page: str) -> Optional[str]:
+        if "/" not in page:
+            return None
+        return page.split("/")[0]
+
     @staticmethod
     def has_source(page: str) -> bool:
         return True

--- a/truewiki/namespaces/template/namespace.py
+++ b/truewiki/namespaces/template/namespace.py
@@ -95,6 +95,15 @@ class Namespace(base.Namespace):
         return None
 
     @classmethod
+    def page_get_language(cls, page: str) -> Optional[str]:
+        assert page.startswith("Template/")
+
+        if cls._is_root(page):
+            return None
+
+        return page.split("/")[1]
+
+    @classmethod
     def has_source(cls, page: str) -> bool:
         return not cls._is_root(page) and not cls._is_language_root(page)
 

--- a/truewiki/views/sitemap.py
+++ b/truewiki/views/sitemap.py
@@ -90,4 +90,7 @@ def invalidate_cache() -> None:
 def click_sitemap(frontend_url):
     global FRONTEND_URL
 
+    if frontend_url.endswith("/"):
+        frontend_url = frontend_url[:-1]
+
     FRONTEND_URL = frontend_url

--- a/truewiki/web_routes.py
+++ b/truewiki/web_routes.py
@@ -137,6 +137,29 @@ async def robots(request):
         return web.Response(body="User-agent: *", content_type="text/plain")
 
 
+@routes.get("/search")
+@csp_header
+async def search(request):
+    site = sitemap.FRONTEND_URL
+    if not site:
+        return web.HTTPNotFound()
+
+    if site.startswith("http://"):
+        site = site[len("http://") :]
+    elif site.startswith("https://"):
+        site = site[len("https://") :]
+
+    query = request.query.get("query", "")
+    if query:
+        query += " "
+
+    language = request.query.get("language", "")
+    if language:
+        language = f"%2F{language}%2F"
+
+    return web.HTTPFound(f"https://duckduckgo.com/?q={query}site%3A{site}{language}")
+
+
 @routes.get("/edit/{page:.*}")
 @csp_header
 async def edit_page(request):

--- a/truewiki/wiki_page.py
+++ b/truewiki/wiki_page.py
@@ -114,6 +114,10 @@ class WikiPage(Page):
         namespace = page.split("/")[0]
         return NAMESPACES.get(namespace, NAMESPACE_DEFAULT_PAGE).page_get_correct_case(page)
 
+    def page_get_language(self, page: str) -> Optional[str]:
+        namespace = page.split("/")[0]
+        return NAMESPACES.get(namespace, NAMESPACE_DEFAULT_PAGE).page_get_language(page)
+
     def has_source(self, page: str) -> bool:
         # "License" is a special page, of which we never show the source.
         if page == "License":

--- a/truewiki/wrapper.py
+++ b/truewiki/wrapper.py
@@ -10,6 +10,7 @@ from . import (
     config,
     singleton,
 )
+from .views import sitemap
 from .wiki_page import WikiPage
 
 
@@ -30,6 +31,9 @@ def wrap_page(page, wrapper, variables, templates):
         variables["does_exist"] = "1" if wiki_page.has_history(page) else ""
         variables["create_page_name"] = wiki_page.get_create_page_name(page)
         variables["repository_url"] = singleton.STORAGE.get_repository_url()
+
+    variables["language"] = wiki_page.page_get_language(page) or ""
+    variables["has_search"] = "1" if sitemap.FRONTEND_URL else ""
 
     variables["css"] = config.HTML_SNIPPETS["css"]
     variables["favicon"] = config.FAVICON


### PR DESCRIPTION
It requires the --frontend-url to be set, as otherwise we cannot
scope the DuckDuckGo results.