### PR TITLE
Fix: don't strip "Main Page" from sitemap

### DIFF
--- a/truewiki/views/sitemap.py
+++ b/truewiki/views/sitemap.py
@@ -34,8 +34,6 @@ def view() -> web.Response:
         for page, page_data in metadata.PAGES.items():
             if page.startswith("Page/"):
                 page = page[len("Page/") :]
-            if page.endswith("/Main Page"):
-                page = page[: -len("/Main Page")] + "/"
             page = urllib.parse.quote(page)
 
             body += "<url>\n"


### PR DESCRIPTION
Bing.com for one doesn't seem to pick up URLs ending with /.
Hopefully is adding "Main Page" behind it again a solution that
works for it. There isn't really a drawback here, other than an
URL that looks a bit more ugly.