### PR TITLE
added edit summaries

### DIFF
--- a/templates/Edit.mediawiki
+++ b/templates/Edit.mediawiki
@@ -98,7 +98,7 @@
             }}
 
             <textarea name="content" style="width: 100%;" rows=30>{{page}}</textarea>
-
+            <input type="text" name="summary" placeholder="Edit Summary..." style="width: 100%;" />
             {{namespace_edit}}
 
             <input type="submit" name="save" value="Save page" /> <input type="submit" name="preview" value="Preview page" />

--- a/templates/Edit.mediawiki
+++ b/templates/Edit.mediawiki
@@ -98,7 +98,7 @@
             }}
 
             <textarea name="content" style="width: 100%;" rows=30>{{page}}</textarea>
-            <input type="text" name="summary" placeholder="Edit Summary..." style="width: 100%;" />
+            <input type="text" name="summary" maxlength="500" placeholder="Edit Summary..." style="width: 100%;" />
             {{namespace_edit}}
 
             <input type="submit" name="save" value="Save page" /> <input type="submit" name="preview" value="Preview page" />

--- a/templates/Edit.mediawiki
+++ b/templates/Edit.mediawiki
@@ -98,7 +98,7 @@
             }}
 
             <textarea name="content" style="width: 100%;" rows=30>{{page}}</textarea>
-            <input type="text" name="summary" maxlength="500" placeholder="Edit Summary..." style="width: 100%;" />
+            <input type="text" name="summary" maxlength="500" placeholder="Edit Summary (Optional)..." style="width: 100%;" />
             {{namespace_edit}}
 
             <input type="submit" name="save" value="Save page" /> <input type="submit" name="preview" value="Preview page" />

--- a/truewiki/views/edit.py
+++ b/truewiki/views/edit.py
@@ -45,7 +45,7 @@ def save(user, old_page: str, new_page: str, content: str, payload, summary: str
         commit_message = f"modified: {old_page}"
 
     if summary:
-        commit_message += f"\n User Summary: {summary}"
+        commit_message += f"\n\nUser Summary: {summary}"
 
     old_filename = wiki_page.page_ondisk_name(old_page)
 

--- a/truewiki/views/edit.py
+++ b/truewiki/views/edit.py
@@ -33,20 +33,19 @@ def save(user, old_page: str, new_page: str, content: str, payload, summary: str
         body = source.create_body(wiki_page, user, "Edit", new_page=new_page, page_error=page_error)
         return web.Response(body=body, content_type="text/html")
 
-    # Truncate long edit messages
-    # The html textfield already limits this, but if someone wanted to they could modify the html
-    summary = (summary[:500] + "..(truncated)") if len(summary) > 500 else summary
-
     # If the old page doesn't exist, this creates a page. But it is possible
     # that this is done from an old page with a different name. Make sure the
     # new page always wins in this case.
     if not wiki_page.page_exists(old_page):
         create_new = True
         old_page = new_page
-        commit_message = f"new page: {old_page} \n User Summary: {summary}" if summary else f"new page: {old_page}"
+        commit_message = f"new page: {old_page}"
     else:
         create_new = False
-        commit_message = f"modified: {old_page} \n User Summary: {summary}" if summary else f"modified: {old_page}"
+        commit_message = f"modified: {old_page}"
+
+    if summary:
+        commit_message += f"\n User Summary: {summary}"
 
     old_filename = wiki_page.page_ondisk_name(old_page)
 

--- a/truewiki/views/edit.py
+++ b/truewiki/views/edit.py
@@ -33,16 +33,20 @@ def save(user, old_page: str, new_page: str, content: str, payload, summary: str
         body = source.create_body(wiki_page, user, "Edit", new_page=new_page, page_error=page_error)
         return web.Response(body=body, content_type="text/html")
 
+    # Truncate long edit messages
+    # The html textfield already limits this, but if someone wanted to they could modify the html
+    summary = (summary[:500] + "..(truncated)") if len(summary) > 500 else summary
+
     # If the old page doesn't exist, this creates a page. But it is possible
     # that this is done from an old page with a different name. Make sure the
     # new page always wins in this case.
     if not wiki_page.page_exists(old_page):
         create_new = True
         old_page = new_page
-        commit_message = f"new page: {old_page} - {summary}" if summary else f"new page: {old_page}"
+        commit_message = f"new page: {old_page} \n User Summary: {summary}" if summary else f"new page: {old_page}"
     else:
         create_new = False
-        commit_message = f"modified: {old_page} - {summary}" if summary else f"modified: {old_page}"
+        commit_message = f"modified: {old_page} \n User Summary: {summary}" if summary else f"modified: {old_page}"
 
     old_filename = wiki_page.page_ondisk_name(old_page)
 

--- a/truewiki/views/edit.py
+++ b/truewiki/views/edit.py
@@ -14,7 +14,7 @@ from ..metadata import page_changed
 from ..wiki_page import WikiPage
 
 
-def save(user, old_page: str, new_page: str, content: str, payload) -> web.Response:
+def save(user, old_page: str, new_page: str, content: str, payload, summary: str = None) -> web.Response:
     wiki_page = WikiPage(old_page)
     page_error = wiki_page.page_is_valid(old_page, is_new_page=True)
     if page_error:
@@ -39,10 +39,10 @@ def save(user, old_page: str, new_page: str, content: str, payload) -> web.Respo
     if not wiki_page.page_exists(old_page):
         create_new = True
         old_page = new_page
-        commit_message = f"new page: {old_page}"
+        commit_message = f"new page: {old_page} - {summary}" if summary else f"new page: {old_page}"
     else:
         create_new = False
-        commit_message = f"modified: {old_page}"
+        commit_message = f"modified: {old_page} - {summary}" if summary else f"modified: {old_page}"
 
     old_filename = wiki_page.page_ondisk_name(old_page)
 

--- a/truewiki/web_routes.py
+++ b/truewiki/web_routes.py
@@ -192,6 +192,7 @@ async def edit_page_post(request):
     if "content" not in payload:
         raise web.HTTPNotFound()
     content = payload["content"].replace("\r", "")
+    summary = payload["summary"].replace("\r", "")
 
     # Make sure that page names don't contain /../ or anything silly.
     new_page = payload.get("page", page)
@@ -200,7 +201,7 @@ async def edit_page_post(request):
     new_page = f"{path}/{filename}"
 
     if "save" in payload:
-        return edit.save(user, page, new_page, content, payload)
+        return edit.save(user, page, new_page, content, payload, summary)
 
     if "preview" in payload:
         return preview.view(user, page, new_page, content)

--- a/truewiki/web_routes.py
+++ b/truewiki/web_routes.py
@@ -194,6 +194,13 @@ async def edit_page_post(request):
     content = payload["content"].replace("\r", "")
     summary = payload["summary"].replace("\r", "")
 
+    # Make sure summary is not more than 500 chars. This is normally limited
+    # by the HTML form itself, so if this is somehow longer, people have
+    # been messing with the HTML. We should probably just reject the request
+    # at this point.
+    if len(summary) > 500:
+        return web.HTTPBadRequest(reason="Summary exceeds maximum length of 500 characters.")
+
     # Make sure that page names don't contain /../ or anything silly.
     new_page = payload.get("page", page)
     filename = os.path.basename(new_page)

--- a/truewiki/web_routes.py
+++ b/truewiki/web_routes.py
@@ -199,7 +199,7 @@ async def edit_page_post(request):
     # been messing with the HTML. We should probably just reject the request
     # at this point.
     if len(summary) > 500:
-        return web.HTTPBadRequest(reason="Summary exceeds maximum length of 500 characters.")
+        raise web.HTTPBadRequest(reason="Summary exceeds maximum length of 500 characters.")
 
     # Make sure that page names don't contain /../ or anything silly.
     new_page = payload.get("page", page)


### PR DESCRIPTION
With this change, users may specify an edit summary that will be included in the git commit message. Not that unlike wikimedia, the edit summary does not currently support wikimarkup.