### PR TITLE
Add: readonly attrib and notice

### DIFF
--- a/templates/Source.mediawiki
+++ b/templates/Source.mediawiki
@@ -67,7 +67,11 @@
             </ul>
             }}
             <h3>Source</h3>
-            <textarea style="width: 100%;" rows=30>{{page}}</textarea>
+            <div id="edit-locked-notice">
+                <p>You do not have permission to edit this page, because you are not logged in.</p>
+                <p>You can view and copy the source of this page.</p>
+            </div>
+            <textarea style="width: 100%;" rows=30 readonly="">{{page}}</textarea>
             <h3>
                 Templates
             </h3>


### PR DESCRIPTION
The `textarea` field should have the `readonly` attribute so pages that can't be edited will not allow modification of text. Additionally, a text notice has been added above the source text to make it clear to the user why they cannot edit the page, structured similarly to read-only notices on mediawiki.