### PR TITLE
Add: Mobile Support

### DIFF
--- a/static/truewiki/truewiki.css
+++ b/static/truewiki/truewiki.css
@@ -15,7 +15,7 @@ img {
 }
 
 body > * {
-	width: 1020px;
+	max-width: 1020px;
 }
 
 body > header {
@@ -35,8 +35,15 @@ body > nav {
 	height: 32px;
 	margin: 0px auto;
 	min-height: 32px;
-	overflow: hidden;
+	overflow: scroll; /* If the breadcrumbs are longer than the width of the screen, allow horizontal scrolling */
+	scrollbar-width: none;
+	white-space: nowrap;
 }
+
+body > nav::-webkit-scrollbar {
+    display: none;
+}
+
 #navigation-bar {
 	display: flex;
 	margin: 0px;
@@ -107,9 +114,15 @@ main {
 
 #pagename {
     color: white;
-    font-size: 300%;
+    font-size: 200%;
     max-width: 700px;
     padding: 5px 0 0 10px;
+}
+
+@media only screen and (min-width: 992px) {
+    #pagename {
+        font-size: 300%;
+    }
 }
 
 #navigation-bar {
@@ -123,9 +136,17 @@ main {
     padding: 0 6px;
 }
 #navigation-bar.right {
+    visibility: hidden;
     float: right;
     padding-right: 10px;
 }
+
+@media only screen and (min-width: 992px) {
+    #navigation-bar.right {
+        visibility: visible;
+    }
+}
+
 #navigation-bar li.crumb:not(:first-child)::after {
     color: white;
     content: "❱";
@@ -218,6 +239,7 @@ a.new {
 }
 main img {
     max-width: 900px;
+    width: 100%; /* Prevent overflow on small (e.g. mobile) screens */
 }
 
 .magnify {
@@ -322,6 +344,7 @@ pre {
     color: Black;
     line-height: 1.2;
     padding: 10px;
+    white-space: pre-wrap;
 }
 
 .external::after {
@@ -506,10 +529,22 @@ header {
 }
 
 #search {
-    position: absolute;
-    right: 30px;
+    position: -webkit-sticky;
+    position: sticky;
     top: 10px;
+    width: 100%;
 }
+
+@media only screen and (min-width: 992px) {
+    #search {
+        left: 420px;
+        margin: auto;
+        position: relative;
+        top: -80px;
+        width: 152px;
+    }
+}
+
 #search input[type=text] {
     background: #fff;
     border: 1px solid #8d8d8d;
@@ -518,7 +553,7 @@ header {
     margin: 0;
     outline: none;
     padding: 4px 26px 4px 6px;
-    width: 152px;
+    width: 100%;
 }
 
 #search-submit {

--- a/templates/Edit.mediawiki
+++ b/templates/Edit.mediawiki
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
     <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta charset="utf-8" />
         <meta name="robots" content="noindex" />
         {{#if: {{{favicon|}}}|
@@ -20,21 +21,21 @@
                 <a href="{{{user_settings_url}}}">Review access</a>
             </div>
             }}
-            {{#if: {{{has_search|}}}|
-            <div id="search">
-                <form action="/search" target="_new">
-                    {{#if: {{{language|}}}|
-                    <input type="hidden" name="language" value="{{{language}}}" />
-                    }}
-                    <input type="text" autocomplete="off" name="query" value="" placeholder="Search wiki" />
-                    <div id="search-submit">
-                        <input type="submit" value="" />
-                        <div></div>
-                    </div>
-                </form>
-            </div>
-            }}
         </header>
+        {{#if: {{{has_search|}}}|
+        <div id="search">
+            <form action="/search" target="_new">
+                {{#if: {{{language|}}}|
+                <input type="hidden" name="language" value="{{{language}}}" />
+                }}
+                <input type="text" autocomplete="off" name="query" value="" placeholder="Search wiki" />
+                <div id="search-submit">
+                    <input type="submit" value="" />
+                    <div></div>
+                </div>
+            </form>
+        </div>
+        }}
         <nav>
             <ul id="navigation-bar">
                 {{breadcrumbs}}

--- a/templates/Error.mediawiki
+++ b/templates/Error.mediawiki
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
     <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta charset="utf-8" />
         <meta name="robots" content="noindex" />
         {{#if: {{{favicon|}}}|
@@ -15,20 +16,6 @@
                 Error
             </div>
             {{{html_header}}}
-            {{#if: {{{has_search|}}}|
-            <div id="search">
-                <form action="/search" target="_new">
-                    {{#if: {{{language|}}}|
-                    <input type="hidden" name="language" value="{{{language}}}" />
-                    }}
-                    <input type="text" autocomplete="off" name="query" value="" placeholder="Search wiki" />
-                    <div id="search-submit">
-                        <input type="submit" value="" />
-                        <div></div>
-                    </div>
-                </form>
-            </div>
-            }}
         </header>
         <nav>
             <ul id="navigation-bar">
@@ -37,6 +24,20 @@
             <ul id="navigation-bar" class="right">
             </ul>
         </nav>
+        {{#if: {{{has_search|}}}|
+        <div id="search">
+            <form action="/search" target="_new">
+                {{#if: {{{language|}}}|
+                <input type="hidden" name="language" value="{{{language}}}" />
+                }}
+                <input type="text" autocomplete="off" name="query" value="" placeholder="Search wiki" />
+                <div id="search-submit">
+                    <input type="submit" value="" />
+                    <div></div>
+                </div>
+            </form>
+        </div>
+        }}
         <main>
             <h2>Error</h2>
             <p>We are sorry, it seems you hit a page that doesn't exists.</p>

--- a/templates/Login.mediawiki
+++ b/templates/Login.mediawiki
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
     <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta charset="utf-8" />
         <meta name="robots" content="noindex" />
         {{#if: {{{favicon|}}}|
@@ -20,21 +21,21 @@
                 <a href="{{{user_settings_url}}}">Review access</a>
             </div>
             }}
-            {{#if: {{{has_search|}}}|
-            <div id="search">
-                <form action="/search" target="_new">
-                    {{#if: {{{language|}}}|
-                    <input type="hidden" name="language" value="{{{language}}}" />
-                    }}
-                    <input type="text" autocomplete="off" name="query" value="" placeholder="Search wiki" />
-                    <div id="search-submit">
-                        <input type="submit" value="" />
-                        <div></div>
-                    </div>
-                </form>
-            </div>
-            }}
         </header>
+        {{#if: {{{has_search|}}}|
+        <div id="search">
+            <form action="/search" target="_new">
+                {{#if: {{{language|}}}|
+                <input type="hidden" name="language" value="{{{language}}}" />
+                }}
+                <input type="text" autocomplete="off" name="query" value="" placeholder="Search wiki" />
+                <div id="search-submit">
+                    <input type="submit" value="" />
+                    <div></div>
+                </div>
+            </form>
+        </div>
+        }}
         <nav>
             <ul id="navigation-bar" class="right">
                 <li>

--- a/templates/Page.mediawiki
+++ b/templates/Page.mediawiki
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
     <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta charset="utf-8" />
         {{#if: {{{favicon|}}}|
         <link rel="icon" href="{{{favicon}}}" type="image/icon" />
@@ -17,20 +18,6 @@
             {{#if: {{{user_settings_url}}}|
             <div id="review-access">
                 <a href="{{{user_settings_url}}}">Review access</a>
-            </div>
-            }}
-            {{#if: {{{has_search|}}}|
-            <div id="search">
-                <form action="/search" target="_new">
-                    {{#if: {{{language|}}}|
-                    <input type="hidden" name="language" value="{{{language}}}" />
-                    }}
-                    <input type="text" autocomplete="off" name="query" value="" placeholder="Search wiki" />
-                    <div id="search-submit">
-                        <input type="submit" value="" />
-                        <div></div>
-                    </div>
-                </form>
             </div>
             }}
         </header>
@@ -83,6 +70,20 @@
                 }}
             </ul>
         </nav>
+        {{#if: {{{has_search|}}}|
+        <div id="search">
+            <form action="/search" target="_new">
+                {{#if: {{{language|}}}|
+                <input type="hidden" name="language" value="{{{language}}}" />
+                }}
+                <input type="text" autocomplete="off" name="query" value="" placeholder="Search wiki" />
+                <div id="search-submit">
+                    <input type="submit" value="" />
+                    <div></div>
+                </div>
+            </form>
+        </div>
+        }}
         <main>
             <div id="language-bar">
                 <ul>

--- a/templates/Source.mediawiki
+++ b/templates/Source.mediawiki
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
     <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta charset="utf-8" />
         <meta name="robots" content="noindex" />
         {{#if: {{{favicon|}}}|
@@ -20,21 +21,21 @@
                 <a href="{{{user_settings_url}}}">Review access</a>
             </div>
             }}
-            {{#if: {{{has_search|}}}|
-            <div id="search">
-                <form action="/search" target="_new">
-                    {{#if: {{{language|}}}|
-                    <input type="hidden" name="language" value="{{{language}}}" />
-                    }}
-                    <input type="text" autocomplete="off" name="query" value="" placeholder="Search wiki" />
-                    <div id="search-submit">
-                        <input type="submit" value="" />
-                        <div></div>
-                    </div>
-                </form>
-            </div>
-            }}
         </header>
+        {{#if: {{{has_search|}}}|
+        <div id="search">
+            <form action="/search" target="_new">
+                {{#if: {{{language|}}}|
+                <input type="hidden" name="language" value="{{{language}}}" />
+                }}
+                <input type="text" autocomplete="off" name="query" value="" placeholder="Search wiki" />
+                <div id="search-submit">
+                    <input type="submit" value="" />
+                    <div></div>
+                </div>
+            </form>
+        </div>
+        }}
         <nav>
             <ul id="navigation-bar">
                 {{breadcrumbs}}


### PR DESCRIPTION
Alright, this is a small set of changes that has a pretty BIG effect. In short: I've added a bunch of CSS changes to allow graceful handling of mobile clients.

The changes included:

* HTML meta viewport allows for better sizing on different screen DPIs
* `@media` selectors dynamically adjust the CSS to behave differently on desktop and mobile
* Sticky search bar while scrolling (see example picture below)
* Navigation breadcrumbs can horizontally scroll when they grow beyond page width

Some picture examples from the crafty test wiki:

---

![image](https://user-images.githubusercontent.com/14336407/112744947-98f26c00-8f72-11eb-9408-80dd11e6d5c4.png)
Text is easily readable

![image](https://user-images.githubusercontent.com/14336407/112744969-b8899480-8f72-11eb-8aa5-38f8e7f535f3.png)
You can horizontally scroll the breadcrumbs

![image](https://user-images.githubusercontent.com/14336407/112744974-c63f1a00-8f72-11eb-9653-fa3d15c30057.png)
images fit to screen width

![image](https://user-images.githubusercontent.com/14336407/112744990-e4a51580-8f72-11eb-9c14-dd7f983dc1fb.png)
code blocks wrap nicely

![image](https://user-images.githubusercontent.com/14336407/112745150-52057600-8f74-11eb-9188-4ed91bb317bb.png)
sticky search bar