### PR TITLE
Cleanup some GitHub Workflows a bit

### DIFF
--- a/.github/workflows/commit-checker.yml
+++ b/.github/workflows/commit-checker.yml
@@ -15,30 +15,7 @@ jobs:
         fetch-depth: 4
 
     - name: Get pull-request commits
-      run: |
-        # actions/checkout did a merge checkout of the pull-request. As such, the first
-        # commit is the merge commit. This means that on HEAD^ is the base branch, and
-        # on HEAD^2 are the commits from the pull-request. We now check if those trees
-        # have a common parent. If not, we fetch a few more commits till we do. In result,
-        # the log between HEAD^ and HEAD^2 will be the commits in the pull-request.
-        DEPTH=4
-        while [ -z "$(git merge-base HEAD^ HEAD^2)" ]; do
-            git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --deepen=${DEPTH} origin HEAD
-            DEPTH=$(( ${DEPTH} * 4 ))
-        done
-
-        # Just to show which commits we are going to evaluate.
-        echo "Commits in this pull-request:"
-        git log --oneline HEAD^..HEAD^2
+      uses: openttd/actions/checkout-pull-request@v2
 
     - name: Checkout commit-checker
-      uses: actions/checkout@v2
-      with:
-        repository: OpenTTD/OpenTTD-git-hooks
-        path: git-hooks
-        ref: master
-
-    - name: Check commits
-      run: |
-        HOOKS_DIR=./git-hooks/hooks GIT_DIR=.git ./git-hooks/hooks/check-commits.sh HEAD^..HEAD^2
-        echo "Commit checks passed"
+      uses: OpenTTD/OpenTTD-git-hooks@main

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -66,3 +66,19 @@ jobs:
     - name: Black
       run: |
         black -l 120 --check truewiki
+
+  check_annotations:
+    name: Check Annotations
+    needs:
+    - docker
+    - flake8
+    - black
+    # not codeql, as that reports its own status
+
+    if: always() && github.event_name == 'pull_request'
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check annotations
+      uses: OpenTTD/actions/annotation-check@v2


### PR DESCRIPTION
- We now use prepared actions, instead of custom shell scripting
- We now validate if testing doesn't leave any annotation (which is often an indication something is wrong)