### PR TITLE
Fix #126: cache folder is not created when generating sitemap

### DIFF
--- a/truewiki/views/sitemap.py
+++ b/truewiki/views/sitemap.py
@@ -63,6 +63,7 @@ def view() -> web.Response:
 
         if cache_filename:
             # Store in cache for next time it is requested.
+            os.makedirs(os.path.dirname(cache_filename), exist_ok=True)
             with open(cache_filename, "w") as fp:
                 fp.write(body)
 


### PR DESCRIPTION
Fixes #126

If no other page has been cached yet, the cache folder doesn't
exist yet.