### PR TITLE
Fix #127: page_get_language() expects a valid URL, even for error pages

### DIFF
--- a/truewiki/wiki_page.py
+++ b/truewiki/wiki_page.py
@@ -115,6 +115,9 @@ class WikiPage(Page):
         return NAMESPACES.get(namespace, NAMESPACE_DEFAULT_PAGE).page_get_correct_case(page)
 
     def page_get_language(self, page: str) -> Optional[str]:
+        if "/" not in page:
+            return None
+
         namespace = page.split("/")[0]
         return NAMESPACES.get(namespace, NAMESPACE_DEFAULT_PAGE).page_get_language(page)
 


### PR DESCRIPTION
Fixes #127 

When someone access for example "/File", this is not a valid URL.
As such, an error page is generated which calls page_get_language().
This fails, as it is not a valid URL.

Take care of this by doing the minimal validation before calling
the function, and otherwise returning None.