### PR TITLE
Fix: minor CSS touch-ups for mobile support

### DIFF
--- a/static/truewiki/truewiki.css
+++ b/static/truewiki/truewiki.css
@@ -20,7 +20,7 @@ body > * {
 
 body > header {
 	margin: 0px auto;
-	padding: 6px 10px 10px 10px;
+	padding: 6px 10px 6px 10px;
     box-shadow: 0px 0px 5px #000000;
     background-color: #333333;
 	display: flex;
@@ -119,7 +119,7 @@ main {
     padding: 5px 0 0 10px;
 }
 
-@media only screen and (min-width: 992px) {
+@media only screen and (min-width: 1020px) {
     #pagename {
         font-size: 300%;
     }
@@ -141,7 +141,7 @@ main {
     padding-right: 10px;
 }
 
-@media only screen and (min-width: 992px) {
+@media only screen and (min-width: 1020px) {
     #navigation-bar.right {
         visibility: visible;
     }
@@ -239,7 +239,6 @@ a.new {
 }
 main img {
     max-width: 900px;
-    width: 100%; /* Prevent overflow on small (e.g. mobile) screens */
 }
 
 .magnify {
@@ -535,13 +534,18 @@ header {
     width: 100%;
 }
 
-@media only screen and (min-width: 992px) {
+@media only screen and (min-width: 1020px) {
     #search {
         left: 420px;
         margin: auto;
         position: relative;
         top: -80px;
         width: 152px;
+    }
+
+    main {
+        /* search-bar consumes space, even if we moved it away. */
+        margin-top: -10px;
     }
 }
 


### PR DESCRIPTION
During testing for release, I found a few things that bugged me enough to fix it:

- Padding in header was 6px top, 10px bottom. This is fine for desktop, but on mobile it looked really weird. So changed that for both to 6px both.
- `width: 100%` causes images that are uploaded too big but are suppose to render smaller, to size badly. This would be a huge regression for all wiki's using TrueWiki. So I reverted that part. It will make big images boom on mobile, so we do need to find a solution there. This just isn't that ;)
- Changed the min-width from `992px`, which feels random, to `1020px`, the size of the header. This mostly removes an odd period where we do make the header smaller, before going to full mobile. This works for the default CSS, but any wiki making changes to the header is having a hard time with it. And those 30 pixels are not really going to make a difference in day-to-day use.
- The search-bar is `relative`, and as such uses height (even despite the object not being there). This creates a weird gap between `header` and `main`. Fix this by using a negative margin if non-mobile.