### PR TITLE
Fix #164: If-Modified-Since header with an invalid year returned a 500 page

### DIFF
--- a/truewiki/web_routes.py
+++ b/truewiki/web_routes.py
@@ -235,7 +235,15 @@ async def html_page(request):
     page = request.match_info["page"]
     _validate_page(page)
 
-    return view_page.view(user, page, request.if_modified_since)
+    try:
+        if_modified_since = request.if_modified_since
+    except ValueError:
+        # If for example the If-Modified-Since header has an invalid year,
+        # requesting the variable will fail in aiohttp. Capture this and
+        # silently act like there was no If-Modified-Since header instead.
+        if_modified_since = None
+
+    return view_page.view(user, page, if_modified_since)
 
 
 @routes.route("*", "/{tail:.*}")


### PR DESCRIPTION
aiohttp fails to parse the header, and bails out. Capture this
error and just assume the header wasn't set (as it doesn't contain
a value that is useful for us anyway).