### PR TITLE
Fix: put <nav> after <header> on all pages

### DIFF
--- a/static/truewiki/truewiki.css
+++ b/static/truewiki/truewiki.css
@@ -115,6 +115,7 @@ main {
 #pagename {
     color: white;
     font-size: 200%;
+    min-height: 47px;
     max-width: 700px;
     padding: 5px 0 0 10px;
 }

--- a/templates/Edit.mediawiki
+++ b/templates/Edit.mediawiki
@@ -22,20 +22,6 @@
             </div>
             }}
         </header>
-        {{#if: {{{has_search|}}}|
-        <div id="search">
-            <form action="/search" target="_new">
-                {{#if: {{{language|}}}|
-                <input type="hidden" name="language" value="{{{language}}}" />
-                }}
-                <input type="text" autocomplete="off" name="query" value="" placeholder="Search wiki" />
-                <div id="search-submit">
-                    <input type="submit" value="" />
-                    <div></div>
-                </div>
-            </form>
-        </div>
-        }}
         <nav>
             <ul id="navigation-bar">
                 {{breadcrumbs}}
@@ -60,6 +46,20 @@
                 }}
             </ul>
         </nav>
+        {{#if: {{{has_search|}}}|
+        <div id="search">
+            <form action="/search" target="_new">
+                {{#if: {{{language|}}}|
+                <input type="hidden" name="language" value="{{{language}}}" />
+                }}
+                <input type="text" autocomplete="off" name="query" value="" placeholder="Search wiki" />
+                <div id="search-submit">
+                    <input type="submit" value="" />
+                    <div></div>
+                </div>
+            </form>
+        </div>
+        }}
         <main>
             {{#if:{{{page_error|}}}|
             <h3><font color="red">Error saving page</font></h3>

--- a/templates/Login.mediawiki
+++ b/templates/Login.mediawiki
@@ -22,6 +22,13 @@
             </div>
             }}
         </header>
+        <nav>
+            <ul id="navigation-bar" class="right">
+                <li>
+                    <a href="/user/login">Login</a>
+                </li>
+            </ul>
+        </nav>
         {{#if: {{{has_search|}}}|
         <div id="search">
             <form action="/search" target="_new">
@@ -36,13 +43,6 @@
             </form>
         </div>
         }}
-        <nav>
-            <ul id="navigation-bar" class="right">
-                <li>
-                    <a href="/user/login">Login</a>
-                </li>
-            </ul>
-        </nav>
         <main>
             <p>{{{project_name}}}'s wiki relies on external authentication providers.</p>
             <form method="post">

--- a/templates/Source.mediawiki
+++ b/templates/Source.mediawiki
@@ -22,20 +22,6 @@
             </div>
             }}
         </header>
-        {{#if: {{{has_search|}}}|
-        <div id="search">
-            <form action="/search" target="_new">
-                {{#if: {{{language|}}}|
-                <input type="hidden" name="language" value="{{{language}}}" />
-                }}
-                <input type="text" autocomplete="off" name="query" value="" placeholder="Search wiki" />
-                <div id="search-submit">
-                    <input type="submit" value="" />
-                    <div></div>
-                </div>
-            </form>
-        </div>
-        }}
         <nav>
             <ul id="navigation-bar">
                 {{breadcrumbs}}
@@ -60,6 +46,20 @@
                 }}
             </ul>
         </nav>
+        {{#if: {{{has_search|}}}|
+        <div id="search">
+            <form action="/search" target="_new">
+                {{#if: {{{language|}}}|
+                <input type="hidden" name="language" value="{{{language}}}" />
+                }}
+                <input type="text" autocomplete="off" name="query" value="" placeholder="Search wiki" />
+                <div id="search-submit">
+                    <input type="submit" value="" />
+                    <div></div>
+                </div>
+            </form>
+        </div>
+        }}
         <main>
             {{#if:{{{has_errors|}}}|
             <h3>Problems</h3>


### PR DESCRIPTION
Currently only "view" pages were like that, and all other had
the "search" between them. This made styling a real challenge.

Instead now, make sure all pages follow the same flow:
  nav, header, search