### PR TITLE
Fix: main eventloop is not running while webserver is

### DIFF
--- a/truewiki/__main__.py
+++ b/truewiki/__main__.py
@@ -162,7 +162,7 @@ def main(bind, port, storage, frontend_url, cache_time, validate_all):
     register_webroutes(webapp)
     webapp.add_routes(routes)
 
-    web.run_app(webapp, host=bind, port=port, access_log_class=ErrorOnlyAccessLogger)
+    web.run_app(webapp, host=bind, port=port, access_log_class=ErrorOnlyAccessLogger, loop=loop)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
run_app() runs the webserver till it is done (read: never), but
since the latest aiohttp it does this in its own eventloop. Read:
the main eventloop is not running inside run_app().

Fix this by explicitly telling to use the mainloop instead.