### PR TITLE
Add: timestamp-based edit conflict detection

### DIFF
--- a/static/truewiki/truewiki.css
+++ b/static/truewiki/truewiki.css
@@ -478,7 +478,7 @@ ul.gallery .gallerytext {
     width: 14px;
 }
 
-#preview {
+#preview, #edit-conflict-title {
     background: #D52D2D;
     color: white;
     text-align: center;

--- a/templates/Edit.mediawiki
+++ b/templates/Edit.mediawiki
@@ -71,6 +71,10 @@
                 {{errors}}
             </ul>
             }}
+            {{#if:{{{has_edit_conflict|}}}|
+            <div id="edit-conflict-title">Edit Conflict Detected</div>
+            <div id="edit-conflict-message">Someone else has changed this page since you started editing it. If you choose to save your edits, you will overwrite their changes! This may be solved by saving your text (i.e. in notepad) and refreshing this page.</div>
+            }}
             {{#if:{{{is_preview|}}}|
             <div id="preview">This is a preview. Changes have not yet been saved.</div>
             <div id="language-bar">
@@ -103,7 +107,7 @@
             {{namespace_edit}}
 
             <input type="submit" name="save" value="Save page" /> <input type="submit" name="preview" value="Preview page" />
-
+            <input type="hidden" name="edit-nonce" value="{{edit_nonce}}" />
             </form>
             <h3>
                 Templates

--- a/templates/Edit.mediawiki
+++ b/templates/Edit.mediawiki
@@ -73,7 +73,7 @@
             }}
             {{#if:{{{has_edit_conflict|}}}|
             <div id="edit-conflict-title">Edit Conflict Detected</div>
-            <div id="edit-conflict-message">Someone else has changed this page since you started editing it. If you choose to save your edits, you will overwrite their changes! This may be solved by saving your text (i.e. in notepad) and refreshing this page.</div>
+            <div id="edit-conflict-message">Someone else has changed this page since you started editing it. If you choose to save your edits, you will overwrite their changes. By leaving this page (without saving) your changes will be lost.</div>
             }}
             {{#if:{{{is_preview|}}}|
             <div id="preview">This is a preview. Changes have not yet been saved.</div>

--- a/truewiki/storage/git.py
+++ b/truewiki/storage/git.py
@@ -167,7 +167,7 @@ class Storage(local.Storage):
         super().file_rename(old_filename, new_filename)
 
     def get_file_nonce(self, filename: str) -> str:
-        return self._git.head.commit.hexsha if self._git else super().get_file_nonce(filename)
+        return self._git.head.commit.hexsha
 
 
 @click_helper.extend

--- a/truewiki/storage/git.py
+++ b/truewiki/storage/git.py
@@ -78,11 +78,12 @@ class Storage(local.Storage):
         super().prepare()
 
         try:
-            return git.Repo(self.folder)
+            self._git = git.Repo(self.folder)
         except git.exc.NoSuchPathError:
-            return self._init_repository()
+            self._git = self._init_repository()
         except git.exc.InvalidGitRepositoryError:
-            return self._init_repository()
+            self._git = self._init_repository()
+        return self._git
 
     def _init_repository(self):
         _git = git.Repo.init(self.folder)
@@ -164,6 +165,9 @@ class Storage(local.Storage):
         self._files_added.append(new_filename)
 
         super().file_rename(old_filename, new_filename)
+
+    def get_file_nonce(self, filename: str) -> str:
+        return self._git.head.commit.hexsha if self._git else super().get_file_nonce(filename)
 
 
 @click_helper.extend

--- a/truewiki/storage/local.py
+++ b/truewiki/storage/local.py
@@ -36,6 +36,9 @@ class Storage:
     def get_repository_url(self):
         return ""
 
+    def get_file_nonce(self, filename: str) -> str:
+        return str(os.path.getmtime(f"{self._folder}/{filename}"))
+
     def file_exists(self, filename: str) -> bool:
         return os.path.exists(f"{self._folder}/{filename}")
 

--- a/truewiki/views/preview.py
+++ b/truewiki/views/preview.py
@@ -7,7 +7,7 @@ from . import (
 from ..wiki_page import WikiPage
 
 
-def view(user, old_page: str, new_page: str, body: str, summary: str = None) -> web.Response:
+def view(user, old_page: str, new_page: str, body: str, summary: str = None, has_edit_conflict=False) -> web.Response:
     wiki_page = WikiPage(old_page)
     page_error = wiki_page.page_is_valid(old_page, is_new_page=True)
     if page_error:
@@ -23,6 +23,13 @@ def view(user, old_page: str, new_page: str, body: str, summary: str = None) -> 
         page_error = wiki_page.page_is_valid(new_page, is_new_page=True)
 
     body = source.create_body(
-        wiki_page, user, "Edit", preview=body, summary=summary, new_page=new_page, page_error=page_error
+        wiki_page,
+        user,
+        "Edit",
+        preview=body,
+        summary=summary,
+        new_page=new_page,
+        page_error=page_error,
+        has_edit_conflict=has_edit_conflict,
     )
     return web.Response(body=body, content_type="text/html")

--- a/truewiki/views/source.py
+++ b/truewiki/views/source.py
@@ -14,7 +14,16 @@ from ..wiki_page import (
 from ..wrapper import wrap_page
 
 
-def create_body(wiki_page: WikiPage, user, wrapper, preview=None, summary=None, new_page=None, page_error=None) -> str:
+def create_body(
+    wiki_page: WikiPage,
+    user,
+    wrapper,
+    preview=None,
+    summary=None,
+    new_page=None,
+    page_error=None,
+    has_edit_conflict=False,
+) -> str:
     ondisk_name = wiki_page.page_ondisk_name(wiki_page.page)
 
     if preview is not None:
@@ -67,11 +76,13 @@ def create_body(wiki_page: WikiPage, user, wrapper, preview=None, summary=None, 
         "breadcrumbs": breadcrumb.create(wiki_page.page),
         "namespace_edit": wiki_page.add_edit_content() if new_page else "",
         "summary_text": summary if summary else "",
+        "edit_nonce": singleton.STORAGE.get_file_nonce(ondisk_name),
     }
     variables = {
         "has_templates_used": "1" if templates_used else "",
         "has_used_on_pages": "1" if used_on_pages else "",
         "has_errors": "1" if errors else "",
+        "has_edit_conflict": has_edit_conflict if has_edit_conflict else "",
         "display_name": html.escape(user.display_name) if user else "",
         "user_settings_url": user.get_settings_url() if user else "",
         "is_preview": "1" if preview is not None else "",

--- a/truewiki/web_routes.py
+++ b/truewiki/web_routes.py
@@ -23,7 +23,6 @@ from .user_session import (
     SESSION_COOKIE_NAME,
     get_user_by_bearer,
 )
-
 from .wiki_page import WikiPage
 
 log = logging.getLogger(__name__)

--- a/truewiki/web_routes.py
+++ b/truewiki/web_routes.py
@@ -24,6 +24,8 @@ from .user_session import (
     get_user_by_bearer,
 )
 
+from .wiki_page import WikiPage
+
 log = logging.getLogger(__name__)
 routes = web.RouteTableDef()
 
@@ -193,6 +195,7 @@ async def edit_page_post(request):
         raise web.HTTPNotFound()
     content = payload["content"].replace("\r", "")
     summary = payload["summary"].replace("\r", "")
+    user_edit_nonce = payload["edit-nonce"].replace("\r", "")
 
     # Make sure summary is not more than 500 chars. This is normally limited
     # by the HTML form itself, so if this is somehow longer, people have
@@ -206,8 +209,12 @@ async def edit_page_post(request):
     filename = os.path.basename(new_page)
     path = os.path.normpath(os.path.dirname(new_page))
     new_page = f"{path}/{filename}"
+    source_edit_nonce = singleton.STORAGE.get_file_nonce(WikiPage.page_ondisk_name(new_page))
 
     if "save" in payload:
+        if user_edit_nonce != source_edit_nonce:
+            return preview.view(user, page, new_page, content, summary, has_edit_conflict=True)
+
         return edit.save(user, page, new_page, content, payload, summary)
 
     if "preview" in payload:

--- a/truewiki/wiki_page.py
+++ b/truewiki/wiki_page.py
@@ -91,7 +91,8 @@ class WikiPage(Page):
         namespace = page.split("/")[0]
         return NAMESPACES.get(namespace, NAMESPACE_DEFAULT_PAGE).page_exists(page)
 
-    def page_ondisk_name(self, page: str) -> str:
+    @staticmethod
+    def page_ondisk_name(page: str) -> str:
         namespace = page.split("/")[0]
         return NAMESPACES.get(namespace, NAMESPACE_DEFAULT_PAGE).page_ondisk_name(page)
 


### PR DESCRIPTION
This PR adds basic edit conflict detection based on the modified time of the source page.

~~Whenever a user starts editing a page, the server sets a cookie with the last modified time of that page. When submitting changes, the server then checks the cookie's timestamp against the local file's modified timestamp. If they differ, the change is rejected with a warning.~~

~~Also, while I was in there, I added some html to show the user the last modified time. This time is purely for info, changing it would not effect the comparison, which is based purely on the cookie.~~

**Cookie solution has been replaced with a unique value (either a git hash or a timestamp) included with edit POST forms.**

![edit-conflict-example](https://user-images.githubusercontent.com/14336407/149873501-fe350576-31ac-4313-a220-d63371becc4f.png)

* Possible future improvement: first try to use the naive `git merge` functionality, to automatically resolve trivial merge conflicts.
