### PR TITLE
Revert: [Actions] create image for both linux/amd64 and linux/arm64 (#269)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,12 +19,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-
     - name: Checkout
       uses: actions/checkout@v2
       with:
@@ -54,7 +48,6 @@ jobs:
         version: ${{ steps.vars.outputs.version }}
         date: ${{ steps.vars.outputs.date }}
         registry: ghcr.io
-        platform: linux/amd64,linux/arm64
 
     - if: steps.vars.outputs.dry-run == 'false'
       name: Publish


### PR DESCRIPTION
"docker buildx" doesn't allow to capture the sha256 we need for AWS
deployment, so this approach is not going to work.

This reverts commit 7dc1385ddb1eb7804564c78b466f2fc834bc5779.
This reverts commit a38eb38685736212723a3b12baff9373f8ad5b5d.