### PR TITLE
Fix: file collision breaks on files that don't exist

### DIFF
--- a/truewiki/storage/local.py
+++ b/truewiki/storage/local.py
@@ -37,7 +37,11 @@ class Storage:
         return ""
 
     def get_file_nonce(self, filename: str) -> str:
-        return str(os.path.getmtime(f"{self._folder}/{filename}"))
+        return (
+            str(os.path.getmtime(f"{self._folder}/{filename}"))
+            if self.file_exists(f"{self._folder}/{filename}")
+            else "0"
+        )
 
     def file_exists(self, filename: str) -> bool:
         return os.path.exists(f"{self._folder}/{filename}")


### PR DESCRIPTION
I noted that the wiki will return a 500 error when A) using the "local" storage option and B) the file does not yet exist.

This was because the way of generating our one-time code (nonce) uses ```python os.path.getmtime(path)``` which returns a `FileNotFoundError` when there is no file at the path.

This fix simply adds a ternary statement that checks if the file exists, and if it doesn't, defaults to a nonce of 0. This still works as a collision-detection mechanism, because if a user creates and submits a new page while another user happens to be working on the same new page, the upstream nonce will resolve to a modified time, which will not match 0 unless the system clock happens to be exactly Jan 1, 1970 -- an occurrence that is expected to be highly unlikely (and if it _does_ occur, there are likely other issues outside of our control.)