### PR TITLE
Fix: filename regression

### DIFF
--- a/truewiki/storage/local.py
+++ b/truewiki/storage/local.py
@@ -37,11 +37,7 @@ class Storage:
         return ""
 
     def get_file_nonce(self, filename: str) -> str:
-        return (
-            str(os.path.getmtime(f"{self._folder}/{filename}"))
-            if self.file_exists(f"{self._folder}/{filename}")
-            else "0"
-        )
+        return str(os.path.getmtime(f"{self._folder}/{filename}")) if self.file_exists(filename) else "0"
 
     def file_exists(self, filename: str) -> bool:
         return os.path.exists(f"{self._folder}/{filename}")


### PR DESCRIPTION
Re: https://github.com/TrueBrain/TrueWiki/pull/291#discussion_r838937074

We actually do NOT want to append the directory to the filename in local.py when we check for existence, because the calling function does this. By wrapping the filename ourselves, we "double-wrap" it. Never a good idea!