### PR TITLE
Fix: renaming files failed on nonce check for local storage driver

### DIFF
--- a/truewiki/web_routes.py
+++ b/truewiki/web_routes.py
@@ -208,7 +208,7 @@ async def edit_page_post(request):
     filename = os.path.basename(new_page)
     path = os.path.normpath(os.path.dirname(new_page))
     new_page = f"{path}/{filename}"
-    source_edit_nonce = singleton.STORAGE.get_file_nonce(WikiPage.page_ondisk_name(new_page))
+    source_edit_nonce = singleton.STORAGE.get_file_nonce(WikiPage.page_ondisk_name(page))
 
     if "save" in payload:
         if user_edit_nonce != source_edit_nonce:


### PR DESCRIPTION
It calculated the nonce of the new page, rather than the old.
Which is not the intention, as we want to know if the original
page was altered in any way.