### PR TITLE
Fix: categories didn't group templates correctly

### DIFF
--- a/truewiki/namespaces/category/content.py
+++ b/truewiki/namespaces/category/content.py
@@ -28,7 +28,7 @@ def add_content(page: str) -> str:
             page_in_category = page_in_category[len(namespace) :]
             link = f"<li>[[{prefix}{page_in_category}]]</li>"
 
-            if namespace == "Templates/":
+            if namespace == "Template/":
                 items["templates"].append(link)
             elif namespace == "Category/":
                 items["categories"].append(link)


### PR DESCRIPTION
Basically, it always showed templates under "Pages", instead of
under "Templates".