### PR TITLE
Fix: editing a page quickly after editing told you it was edited by someone else

### DIFF
--- a/truewiki/storage/git.py
+++ b/truewiki/storage/git.py
@@ -176,9 +176,6 @@ class Storage(local.Storage):
 
         super().file_rename(old_filename, new_filename)
 
-    def get_file_nonce(self, filename: str) -> str:
-        return self._git.head.commit.hexsha
-
 
 @click_helper.extend
 @click.option(

--- a/truewiki/storage/local.py
+++ b/truewiki/storage/local.py
@@ -37,7 +37,10 @@ class Storage:
         return ""
 
     def get_file_nonce(self, filename: str) -> str:
-        return str(os.path.getmtime(f"{self._folder}/{filename}")) if self.file_exists(filename) else "0"
+        if self.file_exists(filename):
+            return str(os.path.getmtime(f"{self._folder}/{filename}"))
+        else:
+            return "0"
 
     def file_exists(self, filename: str) -> bool:
         return os.path.exists(f"{self._folder}/{filename}")


### PR DESCRIPTION
This happened because the commit was still pending, so the nonce
was based on the old hash. Especially if there are a few commits
pending to be processed, this could easily happen.

By switching to modified-time of the file, like the local storage
backend does, we solve this problem. And it is safe, as TrueWiki
cannot scale out anyway for nodes that allow editing.