### PR TITLE
Fix: git-storage-backend could try to commit several commits at once

### DIFF
--- a/truewiki/storage/github.py
+++ b/truewiki/storage/github.py
@@ -112,6 +112,7 @@ class Storage(GitStorage):
         super().reload()
 
     def commit_done(self):
+        super().commit_done()
         self._run_out_of_process(None, "push")
 
     def get_history_url(self, page):

--- a/truewiki/storage/gitlab.py
+++ b/truewiki/storage/gitlab.py
@@ -55,6 +55,7 @@ class Storage(GitStorage):
         super().reload()
 
     def commit_done(self):
+        super().commit_done()
         self._run_out_of_process(None, "push")
 
     def get_history_url(self, page):


### PR DESCRIPTION
There was an attempt to prevent that, but sadly, an Event was
used instead of a Lock. This meant that when the first commit
returned, all other pending were going through after that, instead
of one by one.

Lock is fair, as in, the first to acquire is the first to be released.