### PR TITLE
Fix: import a non-empty data-folder on first-start for github/gitlab storage backend

### DIFF
--- a/truewiki/storage/git.py
+++ b/truewiki/storage/git.py
@@ -110,7 +110,7 @@ class Storage(local.Storage):
         # Always make sure there is a commit in the working tree, otherwise
         # HEAD is invalid, which results in other nasty problems.
         _git.index.commit(
-            "Add: initial empty commit",
+            "initialize: empty commit",
             author=git.Actor(GIT_USERNAME, GIT_EMAIL),
             committer=git.Actor(GIT_USERNAME, GIT_EMAIL),
         )
@@ -120,7 +120,7 @@ class Storage(local.Storage):
             for filename in _git.untracked_files:
                 _git.index.add(filename)
             _git.index.commit(
-                "Add: initial files",
+                "initialize: import existing files",
                 author=git.Actor(GIT_USERNAME, GIT_EMAIL),
                 committer=git.Actor(GIT_USERNAME, GIT_EMAIL),
             )

--- a/truewiki/storage/gitlab.py
+++ b/truewiki/storage/gitlab.py
@@ -56,7 +56,7 @@ class Storage(GitStorage):
 
     def commit_done(self):
         super().commit_done()
-        self._run_out_of_process(None, "push")
+        self._run_out_of_process(None, "push", _gitlab_branch)
 
     def get_history_url(self, page):
         page = urllib.parse.quote(page)


### PR DESCRIPTION
Before it assumed the remote branch already existed, and would
use that as template. But if that isn't the case, import the
current data folder, and create the remote branch.

This is mostly meant to allow end-to-end testing, which has
already some content in the data-folder.