### PR TITLE
chore(dependabot): allow for more open PRs as some cannot be merged currently

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,4 @@ updates:
   schedule:
     interval: "daily"
   rebase-strategy: "disabled"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
Some PRs are those that still require other libraries to update for. Till that mooment, they cannot be merged. But closing them is also a bad idea, as then we lose sight of the fact other libraries haven't updated yet.