### PR TITLE
fix(login): redirect-url could contain a | that was parsed server-side

### DIFF
--- a/truewiki/views/login.py
+++ b/truewiki/views/login.py
@@ -19,7 +19,7 @@ def view(user, location: str = None) -> str:
     variables = {
         "display_name": user.display_name if user else "",
         "user_settings_url": user.get_settings_url() if user else "",
-        "location": html.escape(location) if location else "",
+        "location": html.escape(location.split("|")[0]) if location else "",
     }
 
     return wrap_page("Login", "Login", variables, templates)


### PR DESCRIPTION
Users do the weirdest things.

Import to note: there is no security impact based on this, as the same could be achieved by editing a page (which everyone can). It still had to obey the same rules, and was still sandboxed in full.

It was just weird.