### PR TITLE
chore(ci): install codecov token to avoid hitting GitHub API rate limits

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -33,6 +33,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+
     - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:
@@ -41,23 +42,27 @@ jobs:
         cache-dependency-path: |
           e2e/requirements.base
           requirements.txt
+
     - uses: actions/cache@v3
       name: Cache Playwright
       id: playwright-cache
       with:
         path: '~/.cache/ms-playwright'
         key: '${{ runner.os }}-playwright'
+
     - name: Set up packages
       run: |
         python -m pip install --upgrade pip
         pip install -r e2e/requirements.base
         pip install -r requirements.txt
         playwright install
+
     - name: Set up remote SSH keys
       run: |
         mkdir -p ~/.ssh
         ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
         ssh-keyscan -t rsa gitlab.com >> ~/.ssh/known_hosts
+
     - name: Playwright (storage=${{ matrix.storage }})
       run: |
         if [ -n "${{ matrix.unset }}" ]; then
@@ -73,5 +78,8 @@ jobs:
         TRUEWIKI_STORAGE_GITHUB_APP_ID: ${{ secrets.E2E_STORAGE_GITHUB_APP_ID }}
         TRUEWIKI_STORAGE_GITHUB_APP_KEY: ${{ secrets.E2E_STORAGE_GITHUB_APP_KEY }}
         TRUEWIKI_STORAGE_GITLAB_PRIVATE_KEY: ${{ secrets.E2E_STORAGE_GITLAB_PRIVATE_KEY }}
+
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This caused failures in upload of codecov reports often and a lot.