### PR TITLE
feat(cache): send an ETag header with rendered pages for better caching capabilities

### DIFF
--- a/truewiki/web_routes.py
+++ b/truewiki/web_routes.py
@@ -242,7 +242,8 @@ async def html_page(request):
     _validate_page(page)
 
     if_modified_since = request.if_modified_since
-    return view_page.view(user, page, if_modified_since)
+    if_none_match = request.if_none_match[0].value if request.if_none_match else None
+    return view_page.view(user, page, if_modified_since, if_none_match)
 
 
 @routes.route("*", "/{tail:.*}")


### PR DESCRIPTION
The ETag is a sha256 hash over the fully rendered page. In constrast to Last-Modified, this value is stable between different runs of the server. It only changes when there is an actual content change.