### PR TITLE
chore(e2e): validate wait_for_url() against full URL

### DIFF
--- a/e2e/e2e_edit.py
+++ b/e2e/e2e_edit.py
@@ -4,7 +4,7 @@ from playwright.sync_api import Page, expect
 def test_edit_page_without_login(page: Page):
     """If we are not logged in, we should be redirected to the login page."""
     page.goto("http://localhost:8080/edit/en/Main%20Page")
-    page.wait_for_url("/user/login?location=edit/en/Main%20Page")
+    page.wait_for_url("http://localhost:8080/user/login?location=edit/en/Main%20Page")
 
 
 def test_create_page(page: Page, login):
@@ -13,12 +13,12 @@ def test_create_page(page: Page, login):
     expect(create).to_be_visible()
     with page.expect_navigation():
         create.click()
-    page.wait_for_url("/edit/en/Main%20Page")
+    page.wait_for_url("http://localhost:8080/edit/en/Main%20Page")
 
     page.locator("[name=content]").fill("My First Edit")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/en/Main%20Page")
+    page.wait_for_url("http://localhost:8080/en/Main%20Page")
 
     expect(page).to_have_title("Unnamed | Unnamed's Wiki")
     expect(page.locator("text=My First Edit")).to_be_visible()
@@ -30,12 +30,12 @@ def test_edit_page(page: Page, login):
     expect(edit).to_be_visible()
     with page.expect_navigation():
         edit.click()
-    page.wait_for_url("/edit/en/Main%20Page")
+    page.wait_for_url("http://localhost:8080/edit/en/Main%20Page")
 
     page.locator("[name=content]").fill("My Second Edit\n\n[[Category:en/MyPages]]\n{{en/Summary}}")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/en/Main%20Page")
+    page.wait_for_url("http://localhost:8080/en/Main%20Page")
 
     expect(page).to_have_title("Unnamed | Unnamed's Wiki")
     expect(page.locator("text=My Second Edit")).to_be_visible()
@@ -47,12 +47,12 @@ def test_rename_page(page: Page, login):
     expect(edit).to_be_visible()
     with page.expect_navigation():
         edit.click()
-    page.wait_for_url("/edit/en/Main%20Page")
+    page.wait_for_url("http://localhost:8080/edit/en/Main%20Page")
 
     page.locator("[name=page]").fill("en/Main Page2")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/en/Main%20Page2")
+    page.wait_for_url("http://localhost:8080/en/Main%20Page2")
 
     expect(page.locator('a:has-text("Main Page2")')).to_be_visible()
 
@@ -63,7 +63,7 @@ def test_create_page_again(page: Page, login):
     expect(create).to_be_visible()
     with page.expect_navigation():
         create.click()
-    page.wait_for_url("/edit/en/Main%20Page")
+    page.wait_for_url("http://localhost:8080/edit/en/Main%20Page")
 
     page.locator("[name=content]").fill(
         "[[Translation:en/Main Page]]\nMy Third Edit\n\n[[Category:en/MyPages]]\n{{en/Summary}}"
@@ -71,7 +71,7 @@ def test_create_page_again(page: Page, login):
     )
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/en/Main%20Page")
+    page.wait_for_url("http://localhost:8080/en/Main%20Page")
 
     expect(page).to_have_title("Unnamed | Unnamed's Wiki")
     expect(page.locator("text=My Third Edit")).to_be_visible()
@@ -85,12 +85,13 @@ def test_rename_page_again(page: Page, login):
     expect(edit).to_be_visible()
     with page.expect_navigation():
         edit.click()
-    page.wait_for_url("/edit/en/Main%20Page")
+    page.wait_for_url("http://localhost:8080/edit/en/Main%20Page")
 
     page.locator("[name=page]").fill("en/Main Page2")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/en/Main%20Page")
+    print(page.url)
+    page.wait_for_url("http://localhost:8080/edit/en/Main%20Page")
 
     expect(page.locator('text=Page name "en/Main Page2" already exists')).to_be_visible()
 
@@ -101,12 +102,12 @@ def test_rename_page_invalid_slash(page: Page, login):
     expect(edit).to_be_visible()
     with page.expect_navigation():
         edit.click()
-    page.wait_for_url("/edit/en/Main%20Page")
+    page.wait_for_url("http://localhost:8080/edit/en/Main%20Page")
 
     page.locator("[name=page]").fill("en/Main Page/")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/edit/en/Main%20Page")
+    page.wait_for_url("http://localhost:8080/edit/en/Main%20Page")
 
     expect(page.locator('text=Page name "en/Main Page/" cannot end with a "/".')).to_be_visible()
 
@@ -117,12 +118,12 @@ def test_rename_page_invalid_name(page: Page, login):
     expect(edit).to_be_visible()
     with page.expect_navigation():
         edit.click()
-    page.wait_for_url("/edit/en/Main%20Page")
+    page.wait_for_url("http://localhost:8080/edit/en/Main%20Page")
 
     page.locator("[name=page]").fill("Main Page")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/edit/en/Main%20Page")
+    page.wait_for_url("http://localhost:8080/edit/en/Main%20Page")
 
     expect(
         page.locator(
@@ -137,12 +138,12 @@ def test_rename_page_invalid_language(page: Page, login):
     expect(edit).to_be_visible()
     with page.expect_navigation():
         edit.click()
-    page.wait_for_url("/edit/en/Main%20Page")
+    page.wait_for_url("http://localhost:8080/edit/en/Main%20Page")
 
     page.locator("[name=page]").fill("zz/Main Page")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/edit/en/Main%20Page")
+    page.wait_for_url("http://localhost:8080/edit/en/Main%20Page")
 
     expect(page.locator('text=Page name "zz/Main Page" is in language "zz" that does not exist.')).to_be_visible()
 
@@ -153,12 +154,12 @@ def test_rename_page_invalid_casing(page: Page, login):
     expect(edit).to_be_visible()
     with page.expect_navigation():
         edit.click()
-    page.wait_for_url("/edit/en/Main%20Page")
+    page.wait_for_url("http://localhost:8080/edit/en/Main%20Page")
 
     page.locator("[name=page]").fill("en/main page2")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/edit/en/Main%20Page")
+    page.wait_for_url("http://localhost:8080/edit/en/Main%20Page")
 
     expect(
         page.locator('text=Page name "en/main page2" conflicts with "en/Main Page2", which already exists.')
@@ -173,11 +174,11 @@ def test_create_empty_page(page: Page, login):
     expect(create).to_be_visible()
     with page.expect_navigation():
         create.click()
-    page.wait_for_url("/edit/en/Empty")
+    page.wait_for_url("http://localhost:8080/edit/en/Empty")
 
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/en/Empty")
+    page.wait_for_url("http://localhost:8080/en/Empty")
 
     expect(page).to_have_title("Unnamed | Empty")
     expect(page.locator("text=There is currently no text on this page.")).to_be_visible()
@@ -219,14 +220,14 @@ def test_create_translation(page: Page, login):
     expect(create).to_be_visible()
     with page.expect_navigation():
         create.click()
-    page.wait_for_url("/edit/de/Main%20Page")
+    page.wait_for_url("http://localhost:8080/edit/de/Main%20Page")
 
     page.locator("[name=content]").fill(
         "[[Translation:en/Main Page]]\nMein dritter Edit\n\n[[Category:de/MyPages]]\n{{de/Summary}}\n{{Page:de/Empty}}"
     )
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/de/Main%20Page")
+    page.wait_for_url("http://localhost:8080/de/Main%20Page")
 
     expect(page).to_have_title("Unnamed | Unnamed's Wiki")
     expect(page.locator("text=Mein dritter Edi")).to_be_visible()
@@ -242,7 +243,7 @@ def test_language_bar(page: Page):
     expect(en).to_be_visible()
     with page.expect_navigation():
         en.click()
-    page.wait_for_url("/en/")
+    page.wait_for_url("http://localhost:8080/en/")
 
     expect(page.locator('strong:has-text("en")')).to_be_visible()
     expect(page.locator("#language-bar >> text=de")).to_be_visible()

--- a/e2e/e2e_login.py
+++ b/e2e/e2e_login.py
@@ -11,7 +11,7 @@ def test_login_page(page: Page):
     expect(login).to_have_attribute("href", "/user/login?location=en/Main%20Page")
     with page.expect_navigation():
         login.click()
-    page.wait_for_url("/user/login?location=en/Main%20Page")
+    page.wait_for_url("http://localhost:8080/user/login?location=en/Main%20Page")
 
     # Make sure we end up on the login page.
     expect(page).to_have_title("Unnamed | Login")
@@ -26,7 +26,7 @@ def test_login_flow(page: Page):
     expect(login).to_be_visible()
     with page.expect_navigation():
         login.click()
-    page.wait_for_url("/user/login")
+    page.wait_for_url("http://localhost:8080/user/login")
 
     # Fill in the developer-login form.
     page.locator("[name=username]").fill("test")
@@ -41,17 +41,17 @@ def test_login_flow(page: Page):
     # Now logout.
     with page.expect_navigation():
         logout.click()
-    page.wait_for_url("/en/Main%20Page")
+    page.wait_for_url("http://localhost:8080/en/Main%20Page")
     expect(page.locator("text=Login")).to_be_visible()
 
 
 def test_login_after_login(page: Page, login):
     """Go to the login URL after being logged in."""
     page.goto("http://localhost:8080/user/login")
-    page.wait_for_url("/en/")
+    page.wait_for_url("http://localhost:8080/en/")
 
 
 def test_login_after_login_with_location(page: Page, login):
     """Go to the login URL after being logged in with a location query string."""
     page.goto("http://localhost:8080/user/login?location=en/Main%20Page")
-    page.wait_for_url("/en/Main%20Page")
+    page.wait_for_url("http://localhost:8080/en/Main%20Page")

--- a/e2e/e2e_namespace_category.py
+++ b/e2e/e2e_namespace_category.py
@@ -10,7 +10,7 @@ def test_category_linked(page: Page):
     with page.expect_navigation():
         category.click()
 
-    page.wait_for_url("/Category/en/MyPages")
+    page.wait_for_url("http://localhost:8080/Category/en/MyPages")
 
     expect(page.locator("main >> text=Unnamed's Wiki")).to_be_visible()
     expect(page.locator("text=Main Page2")).to_be_visible()
@@ -24,12 +24,12 @@ def test_category_edit_page(page: Page, login):
     expect(edit).to_be_visible()
     with page.expect_navigation():
         edit.click()
-    page.wait_for_url("/edit/Category/en/MyPages")
+    page.wait_for_url("http://localhost:8080/edit/Category/en/MyPages")
 
     page.locator("[name=content]").fill("Our category\n\n[[Category:en/folder/OtherPages]]")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/Category/en/MyPages")
+    page.wait_for_url("http://localhost:8080/Category/en/MyPages")
 
     expect(page.locator("text=Our category")).to_be_visible()
     expect(page.locator("text=OtherPages")).to_be_visible()
@@ -44,7 +44,7 @@ def test_category_linked_category(page: Page):
     with page.expect_navigation():
         category.click()
 
-    page.wait_for_url("/Category/en/folder/OtherPages")
+    page.wait_for_url("http://localhost:8080/Category/en/folder/OtherPages")
 
     expect(page.locator("text=Subcategories")).to_be_visible()
     expect(page.locator("main >> text=MyPages")).to_be_visible()
@@ -58,12 +58,12 @@ def test_category_edit_empty(page: Page, login):
     expect(edit).to_be_visible()
     with page.expect_navigation():
         edit.click()
-    page.wait_for_url("/edit/Category/en/folder/OtherPages")
+    page.wait_for_url("http://localhost:8080/edit/Category/en/folder/OtherPages")
 
     page.locator("[name=content]").fill("")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/Category/en/folder/OtherPages")
+    page.wait_for_url("http://localhost:8080/Category/en/folder/OtherPages")
 
     expect(page.locator("text=There is currently no additional text for this category.")).to_be_visible()
 
@@ -76,13 +76,13 @@ def test_category_cannot_edit_root(page: Page, login):
     expect(edit).to_be_visible()
     with page.expect_navigation():
         edit.click()
-    page.wait_for_url("/edit/Category/en/")
+    page.wait_for_url("http://localhost:8080/edit/Category/en/")
 
     page.locator("[name=page]").fill("Category/en/Main Page")
     page.locator("[name=content]").fill("Some text")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/edit/Category/en/")
+    page.wait_for_url("http://localhost:8080/edit/Category/en/")
 
     expect(
         page.locator('text=Page name "Category/en/Main Page" is invalid, as it is automatically generated.')
@@ -97,13 +97,13 @@ def test_category_edit_missing_language(page: Page, login):
     expect(edit).to_be_visible()
     with page.expect_navigation():
         edit.click()
-    page.wait_for_url("/edit/Category/en/")
+    page.wait_for_url("http://localhost:8080/edit/Category/en/")
 
     page.locator("[name=page]").fill("Category/test")
     page.locator("[name=content]").fill("Some text")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/edit/Category/en/")
+    page.wait_for_url("http://localhost:8080/edit/Category/en/")
 
     expect(page.locator('text=Page name "Category/test" is missing a language code.')).to_be_visible()
 
@@ -116,13 +116,13 @@ def test_category_edit_invalid_language(page: Page, login):
     expect(edit).to_be_visible()
     with page.expect_navigation():
         edit.click()
-    page.wait_for_url("/edit/Category/en/")
+    page.wait_for_url("http://localhost:8080/edit/Category/en/")
 
     page.locator("[name=page]").fill("Category/zz/test")
     page.locator("[name=content]").fill("Some text")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/edit/Category/en/")
+    page.wait_for_url("http://localhost:8080/edit/Category/en/")
 
     expect(page.locator('text=Page name "Category/zz/test" is in language "zz" that does not exist.')).to_be_visible()
 
@@ -135,7 +135,7 @@ def test_category_root(page: Page):
     expect(folder).to_be_visible()
     with page.expect_navigation():
         folder.click()
-    page.wait_for_url("/Category/")
+    page.wait_for_url("http://localhost:8080/Category/")
 
     expect(page.locator("text=A list of all the languages which have one or more categories.")).to_be_visible()
     expect(page.locator('main >> a:has-text("en")')).to_be_visible()
@@ -149,7 +149,7 @@ def test_category_language(page: Page):
     expect(folder).to_be_visible()
     with page.expect_navigation():
         folder.click()
-    page.wait_for_url("/Category/en/")
+    page.wait_for_url("http://localhost:8080/Category/en/")
 
     expect(page.locator("text=All the categories that belong to this language.")).to_be_visible()
     expect(page.locator('main >> a:has-text("MyPages")')).to_be_visible()

--- a/e2e/e2e_namespace_file.py
+++ b/e2e/e2e_namespace_file.py
@@ -9,7 +9,7 @@ def test_file_view_empty(page: Page):
     expect(image).to_be_visible()
     with page.expect_navigation():
         image.click()
-    page.wait_for_url("/File/en/Test.png")
+    page.wait_for_url("http://localhost:8080/File/en/Test.png")
 
     expect(page.locator("text=There is currently no file with that name.")).to_be_visible()
 
@@ -34,11 +34,11 @@ def test_file_edit_empty(page: Page, login):
     expect(create).to_be_visible()
     with page.expect_navigation():
         create.click()
-    page.wait_for_url("/edit/File/en/Empty.png")
+    page.wait_for_url("http://localhost:8080/edit/File/en/Empty.png")
 
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/File/en/Empty.png")
+    page.wait_for_url("http://localhost:8080/File/en/Empty.png")
 
     expect(page).to_have_title("Unnamed | Empty.png")
     expect(page.locator("text=This file has no description yet.")).to_be_visible()
@@ -52,14 +52,14 @@ def test_file_edit_without_image(page: Page, login):
     expect(create).to_be_visible()
     with page.expect_navigation():
         create.click()
-    page.wait_for_url("/edit/File/en/Test.png")
+    page.wait_for_url("http://localhost:8080/edit/File/en/Test.png")
 
     expect(page.locator("text=Upload new file")).to_be_visible()
 
     page.locator("[name=content]").fill("My First Upload\n[[Category:en/MyPictures]]")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/File/en/Test.png")
+    page.wait_for_url("http://localhost:8080/File/en/Test.png")
 
     expect(page).to_have_title("Unnamed | Test.png")
     expect(page.locator("text=My First Upload")).to_be_visible()
@@ -74,7 +74,7 @@ def test_file_upload_invalid_image(page: Page, login):
     expect(create).to_be_visible()
     with page.expect_navigation():
         create.click()
-    page.wait_for_url("/edit/File/en/Test.png")
+    page.wait_for_url("http://localhost:8080/edit/File/en/Test.png")
 
     expect(page.locator("text=Upload new file")).to_be_visible()
 
@@ -82,7 +82,7 @@ def test_file_upload_invalid_image(page: Page, login):
     page.locator("[name=content]").fill("My First Upload\n[[Category:en/MyPictures]]")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/File/en/Test.png")
+    page.wait_for_url("http://localhost:8080/edit/File/en/Test.png")
 
     expect(
         page.locator('text=Uploaded file "invalid.txt" is not a valid image. Only PNG, GIF, and JPEG is supported.')
@@ -97,7 +97,7 @@ def test_file_upload_invalid_png(page: Page, login):
     expect(create).to_be_visible()
     with page.expect_navigation():
         create.click()
-    page.wait_for_url("/edit/File/en/Test.png")
+    page.wait_for_url("http://localhost:8080/edit/File/en/Test.png")
 
     expect(page.locator("text=Upload new file")).to_be_visible()
 
@@ -105,7 +105,7 @@ def test_file_upload_invalid_png(page: Page, login):
     page.locator("[name=content]").fill("My First Upload\n[[Category:en/MyPictures]]")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/File/en/Test.png")
+    page.wait_for_url("http://localhost:8080/edit/File/en/Test.png")
 
     expect(page.locator('text=Uploaded file "invalid.png" is not a valid PNG image.')).to_be_visible()
 
@@ -118,7 +118,7 @@ def test_file_upload_invalid_gif(page: Page, login):
     expect(create).to_be_visible()
     with page.expect_navigation():
         create.click()
-    page.wait_for_url("/edit/File/en/Test.gif")
+    page.wait_for_url("http://localhost:8080/edit/File/en/Test.gif")
 
     expect(page.locator("text=Upload new file")).to_be_visible()
 
@@ -126,7 +126,7 @@ def test_file_upload_invalid_gif(page: Page, login):
     page.locator("[name=content]").fill("My First Upload\n[[Category:en/MyPictures]]")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/File/en/Test.gif")
+    page.wait_for_url("http://localhost:8080/edit/File/en/Test.gif")
 
     expect(page.locator('text=Uploaded file "invalid.gif" is not a valid GIF image.')).to_be_visible()
 
@@ -139,7 +139,7 @@ def test_file_upload_invalid_jpeg(page: Page, login):
     expect(create).to_be_visible()
     with page.expect_navigation():
         create.click()
-    page.wait_for_url("/edit/File/en/Test.jpeg")
+    page.wait_for_url("http://localhost:8080/edit/File/en/Test.jpeg")
 
     expect(page.locator("text=Upload new file")).to_be_visible()
 
@@ -147,7 +147,7 @@ def test_file_upload_invalid_jpeg(page: Page, login):
     page.locator("[name=content]").fill("My First Upload\n[[Category:en/MyPictures]]")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/File/en/Test.jpeg")
+    page.wait_for_url("http://localhost:8080/edit/File/en/Test.jpeg")
 
     expect(page.locator('text=Uploaded file "invalid.jpeg" is not a valid JPEG image.')).to_be_visible()
 
@@ -160,7 +160,7 @@ def test_file_upload_wrong_gif(page: Page, login):
     expect(create).to_be_visible()
     with page.expect_navigation():
         create.click()
-    page.wait_for_url("/edit/File/en/Test.png")
+    page.wait_for_url("http://localhost:8080/edit/File/en/Test.png")
 
     expect(page.locator("text=Upload new file")).to_be_visible()
 
@@ -168,7 +168,7 @@ def test_file_upload_wrong_gif(page: Page, login):
     page.locator("[name=content]").fill("My First Upload\n[[Category:en/MyPictures]]")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/File/en/Test.png")
+    page.wait_for_url("http://localhost:8080/edit/File/en/Test.png")
 
     expect(page.locator('text=Page name "File/en/Test.png" should end with ".gif" if uploading a GIF.')).to_be_visible()
 
@@ -181,7 +181,7 @@ def test_file_upload_wrong_jpeg(page: Page, login):
     expect(create).to_be_visible()
     with page.expect_navigation():
         create.click()
-    page.wait_for_url("/edit/File/en/Test.png")
+    page.wait_for_url("http://localhost:8080/edit/File/en/Test.png")
 
     expect(page.locator("text=Upload new file")).to_be_visible()
 
@@ -189,7 +189,7 @@ def test_file_upload_wrong_jpeg(page: Page, login):
     page.locator("[name=content]").fill("My First Upload\n[[Category:en/MyPictures]]")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/File/en/Test.png")
+    page.wait_for_url("http://localhost:8080/edit/File/en/Test.png")
 
     expect(
         page.locator('text=Page name "File/en/Test.png" should end with ".jpeg" if uploading a JPEG.')
@@ -204,7 +204,7 @@ def test_file_upload_png(page: Page, login):
     expect(create).to_be_visible()
     with page.expect_navigation():
         create.click()
-    page.wait_for_url("/edit/File/en/Test.png")
+    page.wait_for_url("http://localhost:8080/edit/File/en/Test.png")
 
     expect(page.locator("text=Upload new file")).to_be_visible()
 
@@ -212,7 +212,7 @@ def test_file_upload_png(page: Page, login):
     page.locator("[name=content]").fill("My First Upload\n[[Category:en/MyPictures]]")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/File/en/Test.png")
+    page.wait_for_url("http://localhost:8080/File/en/Test.png")
 
     expect(page).to_have_title("Unnamed | Test.png")
     expect(page.locator("text=My First Upload")).to_be_visible()
@@ -229,7 +229,7 @@ def test_file_upload_wrong_png(page: Page, login):
     expect(create).to_be_visible()
     with page.expect_navigation():
         create.click()
-    page.wait_for_url("/edit/File/en/Test.gif")
+    page.wait_for_url("http://localhost:8080/edit/File/en/Test.gif")
 
     expect(page.locator("text=Upload new file")).to_be_visible()
 
@@ -237,7 +237,7 @@ def test_file_upload_wrong_png(page: Page, login):
     page.locator("[name=content]").fill("My Second Upload\n[[Category:en/MyPictures]]")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/File/en/Test.gif")
+    page.wait_for_url("http://localhost:8080/edit/File/en/Test.gif")
 
     expect(page.locator('text=Page name "File/en/Test.gif" should end with ".png" if uploading a PNG.')).to_be_visible()
 
@@ -250,7 +250,7 @@ def test_file_upload_gif(page: Page, login):
     expect(create).to_be_visible()
     with page.expect_navigation():
         create.click()
-    page.wait_for_url("/edit/File/en/Test.gif")
+    page.wait_for_url("http://localhost:8080/edit/File/en/Test.gif")
 
     expect(page.locator("text=Upload new file")).to_be_visible()
 
@@ -258,7 +258,7 @@ def test_file_upload_gif(page: Page, login):
     page.locator("[name=content]").fill("My Second Upload\n[[Category:en/MyPictures]]")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/File/en/Test.gif")
+    page.wait_for_url("http://localhost:8080/File/en/Test.gif")
 
     expect(page).to_have_title("Unnamed | Test.gif")
     expect(page.locator("text=My Second Upload")).to_be_visible()
@@ -273,7 +273,7 @@ def test_file_upload_jpeg(page: Page, login):
     expect(create).to_be_visible()
     with page.expect_navigation():
         create.click()
-    page.wait_for_url("/edit/File/en/Test.jpeg")
+    page.wait_for_url("http://localhost:8080/edit/File/en/Test.jpeg")
 
     expect(page.locator("text=Upload new file")).to_be_visible()
 
@@ -281,7 +281,7 @@ def test_file_upload_jpeg(page: Page, login):
     page.locator("[name=content]").fill("My Third Upload\n[[Category:en/MyPictures]]")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/File/en/Test.jpeg")
+    page.wait_for_url("http://localhost:8080/File/en/Test.jpeg")
 
     expect(page).to_have_title("Unnamed | Test.jpeg")
     expect(page.locator("text=My Third Upload")).to_be_visible()
@@ -296,7 +296,7 @@ def test_file_cannot_rename(page: Page, login):
     expect(edit).to_be_visible()
     with page.expect_navigation():
         edit.click()
-    page.wait_for_url("/edit/File/en/Test.png")
+    page.wait_for_url("http://localhost:8080/edit/File/en/Test.png")
 
     expect(page.locator("text=Pages cannot be renamed if they are used by other pages.")).to_be_visible()
 
@@ -309,12 +309,12 @@ def test_file_cannot_rename_extension(page: Page, login):
     expect(edit).to_be_visible()
     with page.expect_navigation():
         edit.click()
-    page.wait_for_url("/edit/File/en/Test.jpeg")
+    page.wait_for_url("http://localhost:8080/edit/File/en/Test.jpeg")
 
     page.locator("[name=page]").fill("File/en/Test2.png")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/File/en/Test.jpeg")
+    page.wait_for_url("http://localhost:8080/edit/File/en/Test.jpeg")
 
     expect(page.locator("text=Cannot rename extension of a file.")).to_be_visible()
 
@@ -327,12 +327,12 @@ def test_file_rename(page: Page, login):
     expect(edit).to_be_visible()
     with page.expect_navigation():
         edit.click()
-    page.wait_for_url("/edit/File/en/Test.jpeg")
+    page.wait_for_url("http://localhost:8080/edit/File/en/Test.jpeg")
 
     page.locator("[name=page]").fill("File/en/Test2.jpeg")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/File/en/Test2.jpeg")
+    page.wait_for_url("http://localhost:8080/File/en/Test2.jpeg")
 
 
 def test_file_root(page: Page):
@@ -343,7 +343,7 @@ def test_file_root(page: Page):
     expect(folder).to_be_visible()
     with page.expect_navigation():
         folder.click()
-    page.wait_for_url("/File/")
+    page.wait_for_url("http://localhost:8080/File/")
 
     expect(page.locator("text=A list of all the languages which have one or more files.")).to_be_visible()
     expect(page.locator('main >> a:has-text("en")')).to_be_visible()
@@ -357,7 +357,7 @@ def test_file_language(page: Page):
     expect(folder).to_be_visible()
     with page.expect_navigation():
         folder.click()
-    page.wait_for_url("/File/en/")
+    page.wait_for_url("http://localhost:8080/File/en/")
 
     expect(page.locator("text=All the files that belong to this language.")).to_be_visible()
     expect(page.locator('main >> a:has-text("Test.png")')).to_be_visible()
@@ -380,13 +380,13 @@ def test_file_cannot_edit_root(page: Page, login):
     expect(edit).to_be_visible()
     with page.expect_navigation():
         edit.click()
-    page.wait_for_url("/edit/File/en/Test2.png")
+    page.wait_for_url("http://localhost:8080/edit/File/en/Test2.png")
 
     page.locator("[name=page]").fill("File/en/Testing/Main Page")
     page.locator("[name=content]").fill("Some text")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/edit/File/en/Test2.png")
+    page.wait_for_url("http://localhost:8080/edit/File/en/Test2.png")
 
     expect(
         page.locator('text=Page name "File/en/Testing/Main Page" is invalid, as it is automatically generated.')
@@ -401,13 +401,13 @@ def test_file_cannot_edit_language(page: Page, login):
     expect(edit).to_be_visible()
     with page.expect_navigation():
         edit.click()
-    page.wait_for_url("/edit/File/en/Test2.png")
+    page.wait_for_url("http://localhost:8080/edit/File/en/Test2.png")
 
     page.locator("[name=page]").fill("File/en/Main Page")
     page.locator("[name=content]").fill("Some text")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/edit/File/en/Test2.png")
+    page.wait_for_url("http://localhost:8080/edit/File/en/Test2.png")
 
     expect(
         page.locator('text=Page name "File/en/Main Page" is invalid, as it is automatically generated.')
@@ -422,13 +422,13 @@ def test_file_edit_missing_language(page: Page, login):
     expect(edit).to_be_visible()
     with page.expect_navigation():
         edit.click()
-    page.wait_for_url("/edit/File/en/Test2.png")
+    page.wait_for_url("http://localhost:8080/edit/File/en/Test2.png")
 
     page.locator("[name=page]").fill("File/test")
     page.locator("[name=content]").fill("Some text")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/edit/File/en/Test2.png")
+    page.wait_for_url("http://localhost:8080/edit/File/en/Test2.png")
 
     expect(page.locator('text=Page name "File/test" is missing a language code.')).to_be_visible()
 
@@ -441,13 +441,13 @@ def test_file_edit_invalid_language(page: Page, login):
     expect(edit).to_be_visible()
     with page.expect_navigation():
         edit.click()
-    page.wait_for_url("/edit/File/en/Test2.png")
+    page.wait_for_url("http://localhost:8080/edit/File/en/Test2.png")
 
     page.locator("[name=page]").fill("File/zz/test")
     page.locator("[name=content]").fill("Some text")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/edit/File/en/Test2.png")
+    page.wait_for_url("http://localhost:8080/edit/File/en/Test2.png")
 
     expect(page.locator('text=Page name "File/zz/test" is in language "zz" that does not exist.')).to_be_visible()
 
@@ -461,7 +461,7 @@ def test_files_linked_category(page: Page):
     with page.expect_navigation():
         category.click()
 
-    page.wait_for_url("/Category/en/MyPictures")
+    page.wait_for_url("http://localhost:8080/Category/en/MyPictures")
 
     expect(page.locator('h2:has-text("Files")')).to_be_visible()
     expect(page.locator("main >> text=Test.png")).to_be_visible()

--- a/e2e/e2e_namespace_folder.py
+++ b/e2e/e2e_namespace_folder.py
@@ -9,7 +9,7 @@ def test_folder_main_page(page: Page):
     expect(folder).to_be_visible()
     with page.expect_navigation():
         folder.click()
-    page.wait_for_url("/Folder/Page/en/")
+    page.wait_for_url("http://localhost:8080/Folder/Page/en/")
 
     expect(page.locator("text=All the pages and folders inside this folder.")).to_be_visible()
     expect(page.locator('main >> a:has-text("Main Page2")')).to_be_visible()
@@ -30,7 +30,7 @@ def test_folder_namespace(page: Page):
     expect(folder).to_be_visible()
     with page.expect_navigation():
         folder.click()
-    page.wait_for_url("/Folder/Page/")
+    page.wait_for_url("http://localhost:8080/Folder/Page/")
 
     expect(page.locator("text=A list of all the languages within this namespace.")).to_be_visible()
     expect(page.locator('main >> a:has-text("en")')).to_be_visible()
@@ -44,7 +44,7 @@ def test_folder_root(page: Page):
     expect(folder).to_be_visible()
     with page.expect_navigation():
         folder.click()
-    page.wait_for_url("/Folder/")
+    page.wait_for_url("http://localhost:8080/Folder/")
 
     expect(page.locator("text=A list of all namespaces with files and folders.")).to_be_visible()
     expect(page.locator('main >> a:has-text("Page")')).to_be_visible()

--- a/e2e/e2e_namespace_template.py
+++ b/e2e/e2e_namespace_template.py
@@ -17,12 +17,12 @@ def test_template_edit(page: Page, login):
     expect(create).to_be_visible()
     with page.expect_navigation():
         create.click()
-    page.wait_for_url("/edit/Template/en/Summary")
+    page.wait_for_url("http://localhost:8080/edit/Template/en/Summary")
 
     page.locator("[name=content]").fill("My First Template\n[[Category:en/MyTemplates]]")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/Template/en/Summary")
+    page.wait_for_url("http://localhost:8080/Template/en/Summary")
 
     expect(page).to_have_title("Unnamed | Summary")
     expect(page.locator("text=My First Template")).to_be_visible()
@@ -36,12 +36,12 @@ def test_template_create_link(page: Page, login):
     expect(create).to_be_visible()
     with page.expect_navigation():
         create.click()
-    page.wait_for_url("/edit/Template/en/OtherTemplate")
+    page.wait_for_url("http://localhost:8080/edit/Template/en/OtherTemplate")
 
     page.locator("[name=content]").fill("{{en/Summary}}")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/Template/en/OtherTemplate")
+    page.wait_for_url("http://localhost:8080/Template/en/OtherTemplate")
 
     expect(page).to_have_title("Unnamed | OtherTemplate")
     expect(page.locator("text=My First Template")).to_be_visible()
@@ -55,11 +55,11 @@ def test_template_create_empty(page: Page, login):
     expect(create).to_be_visible()
     with page.expect_navigation():
         create.click()
-    page.wait_for_url("/edit/Template/en/Empty")
+    page.wait_for_url("http://localhost:8080/edit/Template/en/Empty")
 
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/Template/en/Empty")
+    page.wait_for_url("http://localhost:8080/Template/en/Empty")
 
     expect(page).to_have_title("Unnamed | Empty")
     expect(page.locator("text=There is currently no text on this page.")).to_be_visible()
@@ -73,7 +73,7 @@ def test_template_link(page: Page, login):
     expect(create).to_be_visible()
     with page.expect_navigation():
         create.click()
-    page.wait_for_url("/edit/Template/en/Summary")
+    page.wait_for_url("http://localhost:8080/edit/Template/en/Summary")
 
     expect(page.locator("main >> text=OtherTemplate")).to_be_visible()
     expect(page.locator("main >> text=Unnamed's Wiki")).to_be_visible()
@@ -88,7 +88,7 @@ def test_template_link_page(page: Page, login):
     expect(create).to_be_visible()
     with page.expect_navigation():
         create.click()
-    page.wait_for_url("/edit/en/Main%20Page")
+    page.wait_for_url("http://localhost:8080/edit/en/Main%20Page")
 
     expect(page.locator('a:has-text("Summary")')).to_be_visible()
 
@@ -109,7 +109,7 @@ def test_template_root(page: Page):
     expect(folder).to_be_visible()
     with page.expect_navigation():
         folder.click()
-    page.wait_for_url("/Template/")
+    page.wait_for_url("http://localhost:8080/Template/")
 
     expect(page.locator("text=A list of all the languages which have one or more templates.")).to_be_visible()
     expect(page.locator('main >> a:has-text("en")')).to_be_visible()
@@ -123,7 +123,7 @@ def test_template_language(page: Page):
     expect(folder).to_be_visible()
     with page.expect_navigation():
         folder.click()
-    page.wait_for_url("/Template/en/")
+    page.wait_for_url("http://localhost:8080/Template/en/")
 
     expect(page.locator("text=All the templates that belong to this language.")).to_be_visible()
     expect(page.locator('main >> a:has-text("Summary")')).to_be_visible()
@@ -138,13 +138,13 @@ def test_template_cannot_edit_root(page: Page, login):
     expect(edit).to_be_visible()
     with page.expect_navigation():
         edit.click()
-    page.wait_for_url("/edit/Template/en/")
+    page.wait_for_url("http://localhost:8080/edit/Template/en/")
 
     page.locator("[name=page]").fill("Template/en/Main Page")
     page.locator("[name=content]").fill("Some text")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/edit/Template/en/")
+    page.wait_for_url("http://localhost:8080/edit/Template/en/")
 
     expect(
         page.locator('text=Page name "Template/en/Main Page" is invalid, as it is automatically generated.')
@@ -159,13 +159,13 @@ def test_template_edit_missing_language(page: Page, login):
     expect(edit).to_be_visible()
     with page.expect_navigation():
         edit.click()
-    page.wait_for_url("/edit/Template/en/")
+    page.wait_for_url("http://localhost:8080/edit/Template/en/")
 
     page.locator("[name=page]").fill("Template/test")
     page.locator("[name=content]").fill("Some text")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/edit/Template/en/")
+    page.wait_for_url("http://localhost:8080/edit/Template/en/")
 
     expect(page.locator('text=Page name "Template/test" is missing a language code.')).to_be_visible()
 
@@ -178,13 +178,13 @@ def test_template_edit_invalid_language(page: Page, login):
     expect(edit).to_be_visible()
     with page.expect_navigation():
         edit.click()
-    page.wait_for_url("/edit/Template/en/")
+    page.wait_for_url("http://localhost:8080/edit/Template/en/")
 
     page.locator("[name=page]").fill("Template/zz/test")
     page.locator("[name=content]").fill("Some text")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/edit/Template/en/")
+    page.wait_for_url("http://localhost:8080/edit/Template/en/")
 
     expect(page.locator('text=Page name "Template/zz/test" is in language "zz" that does not exist.')).to_be_visible()
 
@@ -198,7 +198,7 @@ def test_template_linked_category(page: Page):
     with page.expect_navigation():
         category.click()
 
-    page.wait_for_url("/Category/en/MyTemplates")
+    page.wait_for_url("http://localhost:8080/Category/en/MyTemplates")
 
     expect(page.locator('h2:has-text("Pages")')).to_be_visible()
     expect(page.locator('h2:has-text("Templates")')).to_be_visible()
@@ -214,6 +214,6 @@ def test_template_cannot_rename(page: Page, login):
     expect(edit).to_be_visible()
     with page.expect_navigation():
         edit.click()
-    page.wait_for_url("/edit/Template/en/Summary")
+    page.wait_for_url("http://localhost:8080/edit/Template/en/Summary")
 
     expect(page.locator("text=Pages cannot be renamed if they are used by other pages.")).to_be_visible()

--- a/e2e/e2e_preview.py
+++ b/e2e/e2e_preview.py
@@ -7,14 +7,14 @@ def test_preview_page(page: Page, login):
     expect(create).to_be_visible()
     with page.expect_navigation():
         create.click()
-    page.wait_for_url("/edit/en/Main%20Page")
+    page.wait_for_url("http://localhost:8080/edit/en/Main%20Page")
 
     expect(page.locator("text=My Third Edit")).to_be_visible()
 
     page.locator("[name=content]").fill("My Preview Edit")
     with page.expect_navigation():
         page.locator("[name=preview]").click()
-    page.wait_for_url("/edit/en/Main%20Page")
+    page.wait_for_url("http://localhost:8080/edit/en/Main%20Page")
 
     expect(page.locator("text=This is a preview. Changes have not yet been saved.")).to_be_visible()
     expect(page.locator('p:has-text("My Preview Edit")')).to_be_visible()
@@ -31,11 +31,11 @@ def test_preview_invalid_slash(page: Page, login):
     expect(edit).to_be_visible()
     with page.expect_navigation():
         edit.click()
-    page.wait_for_url("/edit/en/Main%20Page")
+    page.wait_for_url("http://localhost:8080/edit/en/Main%20Page")
 
     page.locator("[name=page]").fill("en/Main Page/")
     with page.expect_navigation():
         page.locator("[name=preview]").click()
-    page.wait_for_url("/edit/en/Main%20Page")
+    page.wait_for_url("http://localhost:8080/edit/en/Main%20Page")
 
     expect(page.locator('text=Page name "en/Main Page/" cannot end with a "/".')).to_be_visible()

--- a/e2e/e2e_sitemap.py
+++ b/e2e/e2e_sitemap.py
@@ -31,7 +31,7 @@ def test_sitemap_invalidate(page: Page, login):
     page.locator("[name=content]").fill("Invalidate Sitemap")
     with page.expect_navigation():
         page.locator("[name=save]").click()
-    page.wait_for_url("/en/Sitemap%20Change")
+    page.wait_for_url("http://localhost:8080/en/Sitemap%20Change")
 
     expect(page).to_have_title("Unnamed | Sitemap Change")
     expect(page.locator("text=Invalidate Sitemap")).to_be_visible()

--- a/e2e/e2e_source.py
+++ b/e2e/e2e_source.py
@@ -9,7 +9,7 @@ def test_source_page(page: Page):
     expect(source).to_be_visible()
     with page.expect_navigation():
         source.click()
-    page.wait_for_url("/en/Main%20Page.mediawiki")
+    page.wait_for_url("http://localhost:8080/en/Main%20Page.mediawiki")
 
     expect(
         page.locator("text=You do not have permission to edit this page, because you are not logged in.")
@@ -35,7 +35,7 @@ def test_source_template(page: Page):
     expect(source).to_be_visible()
     with page.expect_navigation():
         source.click()
-    page.wait_for_url("/Template/en/Summary.mediawiki")
+    page.wait_for_url("http://localhost:8080/Template/en/Summary.mediawiki")
 
     expect(
         page.locator("text=You do not have permission to edit this page, because you are not logged in.")


### PR DESCRIPTION
Seemly this is a change in Playwright, that partial URLs no longer imply ** in front of them.